### PR TITLE
Enable Google Calendar OAuth toggle

### DIFF
--- a/features/auth/hooks/useGoogleAuth.ts
+++ b/features/auth/hooks/useGoogleAuth.ts
@@ -18,6 +18,7 @@ type AuthState = {
 export const useGoogleAuth = () => {
   const [auth, setAuth] = useState<AuthState | null>(null);
   const [user, setUser] = useState<any>(null);
+  const [isSigningIn, setIsSigningIn] = useState(false);
 
   const [request, response, promptAsync] = Google.useAuthRequest({
     androidClientId: process.env.EXPO_PUBLIC_ANDROID_CLIENT_ID,
@@ -89,10 +90,20 @@ export const useGoogleAuth = () => {
     setUser(null);
   };
 
+  const signIn = async () => {
+    setIsSigningIn(true);
+    try {
+      await promptAsync();
+    } finally {
+      setIsSigningIn(false);
+    }
+  };
+
   return {
     user,
     isSignedIn: !!auth,
-    signIn: () => promptAsync(),
+    signIn,
     signOut,
+    isSigningIn,
   };
 };

--- a/features/settings/SettingsScreen.tsx
+++ b/features/settings/SettingsScreen.tsx
@@ -9,6 +9,7 @@ import {
   useWindowDimensions,
   Platform,
   Image,
+  Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppTheme, ThemeChoice } from '@/hooks/ThemeContext';
@@ -41,7 +42,7 @@ export default function SettingsScreen() {
   const isTablet = width >= 768;
 
   // ★★★ ここで認証の状態とユーザー情報を取得します ★★★
-  const { isSignedIn, user } = useGoogleAuth();
+  const { isSignedIn, user, signIn, signOut } = useGoogleAuth();
 
   const [selectedBgId, setSelectedBgId] = useState<string | null>(null);
 
@@ -224,12 +225,24 @@ export default function SettingsScreen() {
           <Text style={styles.label}>{t('settings.google_calendar_integration', 'Googleカレンダー連携')}</Text>
           <TouchableOpacity
             style={styles.optionRowButton}
-            onPress={() => router.push('/settings/google-sync')}
+            onPress={() => {
+              if (isSignedIn) {
+                Alert.alert(
+                  t('settings.google_calendar_integration', 'Googleカレンダー連携'),
+                  t('settings.disconnect_confirm', '連携を解除しますか？'),
+                  [
+                    { text: t('common.cancel', 'キャンセル'), style: 'cancel' },
+                    { text: t('common.ok', 'OK'), onPress: signOut },
+                  ]
+                );
+              } else {
+                signIn();
+              }
+            }}
           >
             <Text style={styles.optionLabel} numberOfLines={1}>
-              {isSignedIn && user ? user.email : t('settings.not_connected', '未連携')}
+              {isSignedIn ? t('settings.connected', '連携済み') : t('settings.not_connected', '未連携')}
             </Text>
-            <Ionicons name="chevron-forward" size={fontSizes[fontSizeKey] + 2} color={isDark ? '#A0A0A0' : '#888'} />
           </TouchableOpacity>
         </View>
 

--- a/features/settings/google-sync.tsx
+++ b/features/settings/google-sync.tsx
@@ -15,7 +15,7 @@ export default function GoogleSyncSettingsScreen() {
   const router = useRouter();
   const styles = createGoogleSyncStyles(isDark, subColor);
 
-  const { user, isSignedIn, signIn, isSigningIn } = useGoogleAuth();
+  const { user, isSignedIn, signIn, signOut, isSigningIn } = useGoogleAuth();
 
   return (
     <SafeAreaView style={styles.container}>

--- a/locales/en.json
+++ b/locales/en.json
@@ -26,7 +26,14 @@
     "font_size_medium": "Normal",
     "font_size_large": "Large",
     "google_calendar_integration": "Google Calendar Integration",
-        "calendar_background": "Calendar Background"
+        "calendar_background": "Calendar Background",
+        "connected": "Connected",
+        "not_connected": "Not connected",
+        "disconnect_confirm": "Do you want to disconnect?",
+        "login_with_google": "Login with Google",
+        "logout": "Logout",
+        "connected_as": "Connected as {{name}}",
+        "google_sync_description": "By connecting your Google account, you can sync calendar events bidirectionally."
 
   },
   "common": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -34,7 +34,14 @@
     "stop_action": "解除する",
     "view_task_details_tooltip": "タスク詳細を見る",
     "google_calendar_integration": "Googleカレンダー連携",
-    "calendar_background": "カレンダーの背景"
+    "calendar_background": "カレンダーの背景",
+    "connected": "連携済み",
+    "not_connected": "未連携",
+    "disconnect_confirm": "連携を解除しますか？",
+    "login_with_google": "Googleアカウントでログイン",
+    "logout": "ログアウト",
+    "connected_as": "{{name}}として連携中",
+    "google_sync_description": "Googleアカウントと連携することで、カレンダーの予定を双方向で同期できるようになります。"
   },
   "common": {
     "loading": "読み込み中...",


### PR DESCRIPTION
## Summary
- integrate sign-in state handling in `useGoogleAuth`
- show alert to remove linkage from settings
- fix missing signOut import in Google sync screen
- add translation keys for connection states

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68426639ff2483269aa6f26b5c0646e6