### PR TITLE
Fix Android log warnings

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -27,8 +27,6 @@ function InnerLayout() {
 
   useEffect(() => {
     if (Platform.OS === 'android') {
-      const navigationBarColor = isDark ? '#121212' : '#f2f2f2';
-      NavigationBar.setBackgroundColorAsync(navigationBarColor);
       NavigationBar.setButtonStyleAsync(isDark ? 'light' : 'dark');
     }
   }, [isDark]);
@@ -40,11 +38,7 @@ function InnerLayout() {
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="+not-found" />
         </Stack>
-        <StatusBar
-          style={isDark ? 'light' : 'dark'}
-          backgroundColor="transparent"
-          translucent
-        />
+        <StatusBar style={isDark ? 'light' : 'dark'} translucent />
         <Toast />
       </NavThemeProvider>
     </GestureHandlerRootView>

--- a/features/add/components/PhotoPicker.tsx
+++ b/features/add/components/PhotoPicker.tsx
@@ -14,6 +14,7 @@ import {
   Linking,
 } from 'react-native';
 import * as MediaLibrary from 'expo-media-library';
+import Constants from 'expo-constants';
 
 type Photo = { id: string; uri: string };
 
@@ -38,6 +39,7 @@ export const PhotoPicker: React.FC<PhotoPickerProps> = ({
   const [granted, setGranted] = useState<boolean | null>(null);
   const [after, setAfter] = useState<string | undefined>(undefined);
   const [hasNextPage, setHasNextPage] = useState(true);
+  const isExpoGo = Constants.appOwnership === 'expo';
 
   // isMounted のような役割で、アンマウント後の setState を防ぐ (モーダル非表示時)
   const isComponentMounted = useRef(false);
@@ -66,6 +68,16 @@ export const PhotoPicker: React.FC<PhotoPickerProps> = ({
   // --- 2. 権限確認 ---
   useEffect(() => {
     if (visible && granted === null && isComponentMounted.current) {
+      if (isExpoGo) {
+        Alert.alert(
+          '開発ビルドが必要です',
+          'Expo Go ではメディアライブラリへのフルアクセスが利用できません。'
+        );
+        setGranted(false);
+        setIsLoading(false);
+        return;
+      }
+
       console.log('[EFFECT] Visible and permission not determined: Checking permissions.');
       setIsLoading(true); // 権限確認中もローディング表示
       (async () => {


### PR DESCRIPTION
## Summary
- adjust NavigationBar usage when edge-to-edge is enabled
- remove StatusBar backgroundColor
- skip media library permissions when running in Expo Go

## Testing
- `npm install`
- `npx tsc --noEmit` *(fails: Cannot find module 'react-test-renderer', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68426d1d11ec8326822982b8c41ea939