### PR TITLE
Reduce tab switch delay

### DIFF
--- a/features/tasks/TasksScreen.tsx
+++ b/features/tasks/TasksScreen.tsx
@@ -34,7 +34,7 @@ export default function TasksScreen() {
     loading, activeTab, sortMode, sortModalVisible,
     isReordering,
     selectionAnim,
-    folderTabLayouts, selectedTabIndex, // ★ currentContentPage の代わりに selectedTabIndex を使用
+    folderTabLayouts, selectedTabIndex, selectedTabIndexShared,
     pageScrollPosition,
     noFolderName, folderTabs,
     pagerRef, folderTabsScrollViewRef,
@@ -71,6 +71,7 @@ export default function TasksScreen() {
         setFolderTabLayouts={setFolderTabLayouts}
         handleFolderTabPress={handleFolderTabPress}
         pageScrollPosition={pageScrollPosition}
+        selectedTabIndexShared={selectedTabIndexShared}
         folderTabsScrollViewRef={folderTabsScrollViewRef}
       />
 

--- a/features/tasks/components/AnimatedTabItem.tsx
+++ b/features/tasks/components/AnimatedTabItem.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { TouchableOpacity, type LayoutChangeEvent } from 'react-native';
 import Reanimated, { useAnimatedStyle, useDerivedValue, withTiming, interpolateColor } from 'react-native-reanimated';
-import { TAB_MARGIN_RIGHT } from '../constants';
+import { TAB_MARGIN_RIGHT, TAB_SWITCH_THRESHOLD } from '../constants';
 
 type AnimatedTabItemProps = {
   label: string;
@@ -10,6 +10,7 @@ type AnimatedTabItemProps = {
   onPress: (index: number, label: string) => void;
   onTabLayout: (index: number, event: LayoutChangeEvent) => void;
   pageScrollPosition: Reanimated.SharedValue<number>;
+  selectedTabIndexShared: Reanimated.SharedValue<number>;
   selectedTextColor: string;
   unselectedTextColor: string;
   selectedFontWeight: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | undefined;
@@ -24,6 +25,7 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
   onPress,
   onTabLayout,
   pageScrollPosition,
+  selectedTabIndexShared,
   selectedTextColor,
   unselectedTextColor,
   selectedFontWeight,
@@ -42,8 +44,14 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
 
   const activeIndex = useDerivedValue(() => {
     'worklet';
-    // Avoid flickering by simply rounding the pager position
-    return Math.round(pageScrollPosition.value);
+    const current = selectedTabIndexShared.value;
+    const diff = pageScrollPosition.value - current;
+    if (diff >= TAB_SWITCH_THRESHOLD) {
+      return current + 1;
+    } else if (diff <= -TAB_SWITCH_THRESHOLD) {
+      return current - 1;
+    }
+    return current;
   });
 
   const progress = useDerivedValue(() => {

--- a/features/tasks/components/FolderTabsBar.tsx
+++ b/features/tasks/components/FolderTabsBar.tsx
@@ -18,6 +18,7 @@ type FolderTabsBarProps = {
   setFolderTabLayouts: (updater: (prev: Record<number, FolderTabLayout>) => Record<number, FolderTabLayout>) => void;
   handleFolderTabPress: (folderName: string, index: number) => void;
   pageScrollPosition: SharedValue<number>;
+  selectedTabIndexShared: SharedValue<number>;
   folderTabsScrollViewRef: React.RefObject<ScrollView>;
 };
 
@@ -29,6 +30,7 @@ export const FolderTabsBar: React.FC<FolderTabsBarProps> = React.memo(({
   setFolderTabLayouts,
   handleFolderTabPress,
   pageScrollPosition,
+  selectedTabIndexShared,
   folderTabsScrollViewRef,
 }) => {
   const selectedTextColor = styles.folderTabSelectedText.color as string;
@@ -163,6 +165,7 @@ export const FolderTabsBar: React.FC<FolderTabsBarProps> = React.memo(({
               onPress={memoizedOnItemPress}
               onTabLayout={memoizedOnTabLayout}
               pageScrollPosition={pageScrollPosition}
+              selectedTabIndexShared={selectedTabIndexShared}
               selectedTextColor={selectedTextColor}
               unselectedTextColor={unselectedTextColor}
               selectedFontWeight={selectedFontWeight}

--- a/features/tasks/constants.ts
+++ b/features/tasks/constants.ts
@@ -5,3 +5,8 @@ export const SELECTION_BAR_HEIGHT = 60;
 export const FOLDER_TABS_CONTAINER_PADDING_HORIZONTAL = 12;
 export const TAB_MARGIN_RIGHT = 8;
 export const ACCENT_LINE_HEIGHT = 2;
+// When switching folders by sliding, the text color should update almost
+// immediately. This threshold represents how far the page must move (as a
+// fraction of the screen width) before the tab text switches selection state.
+// 0.001 corresponds to 0.1% of the page width.
+export const TAB_SWITCH_THRESHOLD = 0.001;

--- a/features/tasks/hooks/useTasksScreenLogic.ts
+++ b/features/tasks/hooks/useTasksScreenLogic.ts
@@ -53,8 +53,10 @@ export const useTasksScreenLogic = () => {
   
   // ★ ちらつきの原因となっていた currentContentPage を廃止し、新しい確定状態を導入
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const selectedTabIndexShared = useSharedValue(0);
 
   const pageScrollPosition = useSharedValue(0);
+
 
   const noFolderName = useMemo(() => t('common.no_folder_name', 'フォルダなし'), [t]);
 
@@ -139,6 +141,7 @@ export const useTasksScreenLogic = () => {
       // フォルダタブリストが変化したときのみページャーを同期させる
       pagerRef.current?.setPageWithoutAnimation(newIndex);
       pageScrollPosition.value = newIndex;
+      selectedTabIndexShared.value = newIndex;
     }
   }, [folderTabs]);
 
@@ -392,7 +395,9 @@ export const useTasksScreenLogic = () => {
   // ★ タブタップ時の処理を修正
   const handleFolderTabPress = useCallback((_folderName: string, index: number) => {
     if (selectedTabIndex !== index) {
-      // 確定状態を更新
+      // Remember the current index during the animation
+      selectedTabIndexShared.value = selectedTabIndex;
+      // 更新する確定状態
       setSelectedTabIndex(index);
       // PagerView をプログラムで操作
       pagerRef.current?.setPage(index);
@@ -409,11 +414,13 @@ export const useTasksScreenLogic = () => {
   // ★ ページ切り替え完了時の処理を修正
   const handlePageSelected = useCallback((event: PagerViewOnPageSelectedEvent) => {
     const newPageIndex = event.nativeEvent.position;
-    
+
     // 確定状態とUIを同期
     if (selectedTabIndex !== newPageIndex) {
       setSelectedTabIndex(newPageIndex);
     }
+
+    selectedTabIndexShared.value = newPageIndex;
     
     // 現在のタブを中央にスクロール
     scrollFolderTabsToCenter(newPageIndex);
@@ -644,6 +651,7 @@ export const useTasksScreenLogic = () => {
     isReordering, draggingFolder, renameModalVisible, renameTarget,
     selectionAnim, folderTabLayouts, selectedTabIndex, // ★ currentContentPage の代わりに selectedTabIndex を返す
     pageScrollPosition,
+    selectedTabIndexShared,
     noFolderName, folderTabs,
     pagerRef, folderTabsScrollViewRef,
     isSelecting: selectionHook.isSelecting,


### PR DESCRIPTION
## Summary
- let tab highlight change after sliding a tiny amount
- share selected folder tab index with animated items
- add small threshold constant

## Testing
- `npm run tsc --if-present` *(fails: Unknown env config warning)*

------
https://chatgpt.com/codex/tasks/task_e_68427e15328c8326b3fc64dd1b329653