### PR TITLE
Add missing English placeholders

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -119,7 +119,9 @@
     "no_notification": "No notification",
     "photo_selected": "{{count}} selected",
     "no_notification_button": "No Notification",
-    "no_notification_display": "No notification"
+    "no_notification_display": "No notification",
+    "unselected_date_placeholder": "Not selected",
+    "unselected_time_placeholder": "Not selected"
   },
   "edit_task": {
     "title": "Edit Task",


### PR DESCRIPTION
## Summary
- fix localization fallback by adding English text for `unselected_date_placeholder` and `unselected_time_placeholder`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68427b479ddc8326aa1df3a890e70d26