### PR TITLE
Reduce tab switch delay

### DIFF
--- a/features/tasks/TasksScreen.tsx
+++ b/features/tasks/TasksScreen.tsx
@@ -70,6 +70,7 @@ export default function TasksScreen() {
         folderTabLayouts={folderTabLayouts}
         setFolderTabLayouts={setFolderTabLayouts}
         handleFolderTabPress={handleFolderTabPress}
+        selectedTabIndex={selectedTabIndex}
         pageScrollPosition={pageScrollPosition}
         folderTabsScrollViewRef={folderTabsScrollViewRef}
       />

--- a/features/tasks/TasksScreen.tsx
+++ b/features/tasks/TasksScreen.tsx
@@ -34,7 +34,7 @@ export default function TasksScreen() {
     loading, activeTab, sortMode, sortModalVisible,
     isReordering,
     selectionAnim,
-    folderTabLayouts, selectedTabIndex, // ★ currentContentPage の代わりに selectedTabIndex を使用
+    folderTabLayouts, selectedTabIndex, selectedTabIndexShared,
     pageScrollPosition,
     noFolderName, folderTabs,
     pagerRef, folderTabsScrollViewRef,
@@ -71,6 +71,7 @@ export default function TasksScreen() {
         setFolderTabLayouts={setFolderTabLayouts}
         handleFolderTabPress={handleFolderTabPress}
         pageScrollPosition={pageScrollPosition}
+        selectedTabIndexShared={selectedTabIndexShared}
         folderTabsScrollViewRef={folderTabsScrollViewRef}
       />
 

--- a/features/tasks/TasksScreen.tsx
+++ b/features/tasks/TasksScreen.tsx
@@ -34,7 +34,7 @@ export default function TasksScreen() {
     loading, activeTab, sortMode, sortModalVisible,
     isReordering,
     selectionAnim,
-    folderTabLayouts, selectedTabIndex, selectedTabIndexShared,
+    folderTabLayouts, selectedTabIndex,
     pageScrollPosition,
     noFolderName, folderTabs,
     pagerRef, folderTabsScrollViewRef,
@@ -71,7 +71,6 @@ export default function TasksScreen() {
         setFolderTabLayouts={setFolderTabLayouts}
         handleFolderTabPress={handleFolderTabPress}
         pageScrollPosition={pageScrollPosition}
-        selectedTabIndexShared={selectedTabIndexShared}
         folderTabsScrollViewRef={folderTabsScrollViewRef}
       />
 

--- a/features/tasks/components/AnimatedTabItem.tsx
+++ b/features/tasks/components/AnimatedTabItem.tsx
@@ -2,14 +2,14 @@
 import React from 'react';
 import { TouchableOpacity, type LayoutChangeEvent } from 'react-native';
 import Reanimated, { useAnimatedStyle, useDerivedValue, withTiming, interpolateColor } from 'react-native-reanimated';
-import { TAB_MARGIN_RIGHT } from '../constants';
+import { TAB_MARGIN_RIGHT, TAB_SWITCH_THRESHOLD } from '../constants';
 
 type AnimatedTabItemProps = {
   label: string;
   index: number;
   onPress: (index: number, label: string) => void;
   onTabLayout: (index: number, event: LayoutChangeEvent) => void;
-  selectedTabIndexShared: Reanimated.SharedValue<number>;
+  pageScrollPosition: Reanimated.SharedValue<number>;
   selectedTextColor: string;
   unselectedTextColor: string;
   selectedFontWeight: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | undefined;
@@ -23,7 +23,7 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
   index,
   onPress,
   onTabLayout,
-  selectedTabIndexShared,
+  pageScrollPosition,
   selectedTextColor,
   unselectedTextColor,
   selectedFontWeight,
@@ -40,9 +40,15 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
     onTabLayout(index, event);
   };
 
+  const isActive = useDerivedValue(() => {
+    'worklet';
+    const diff = Math.abs(pageScrollPosition.value - index);
+    return diff < TAB_SWITCH_THRESHOLD ? 1 : 0;
+  });
+
   const progress = useDerivedValue(() => {
     'worklet';
-    return withTiming(selectedTabIndexShared.value === index ? 1 : 0, { duration: 200 });
+    return withTiming(isActive.value, { duration: 100 });
   });
 
   const animatedTextStyle = useAnimatedStyle(() => {

--- a/features/tasks/components/AnimatedTabItem.tsx
+++ b/features/tasks/components/AnimatedTabItem.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { TouchableOpacity, type LayoutChangeEvent } from 'react-native';
 import Reanimated, { useAnimatedStyle, useDerivedValue, withTiming, interpolateColor } from 'react-native-reanimated';
-import { TAB_MARGIN_RIGHT } from '../constants';
+import { TAB_MARGIN_RIGHT, TAB_SWITCH_THRESHOLD } from '../constants';
 
 type AnimatedTabItemProps = {
   label: string;
@@ -10,6 +10,7 @@ type AnimatedTabItemProps = {
   onPress: (index: number, label: string) => void;
   onTabLayout: (index: number, event: LayoutChangeEvent) => void;
   pageScrollPosition: Reanimated.SharedValue<number>;
+  selectedTabIndexShared: Reanimated.SharedValue<number>;
   selectedTextColor: string;
   unselectedTextColor: string;
   selectedFontWeight: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | undefined;
@@ -24,6 +25,7 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
   onPress,
   onTabLayout,
   pageScrollPosition,
+  selectedTabIndexShared,
   selectedTextColor,
   unselectedTextColor,
   selectedFontWeight,
@@ -42,8 +44,14 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
 
   const activeIndex = useDerivedValue(() => {
     'worklet';
-    // Avoid flickering by simply rounding the pager position
-    return Math.round(pageScrollPosition.value);
+    const current = selectedTabIndexShared.value;
+    const diff = pageScrollPosition.value - current;
+    if (diff >= TAB_SWITCH_THRESHOLD) {
+      return current + 1;
+    } else if (diff <= -TAB_SWITCH_THRESHOLD) {
+      return current - 1;
+    }
+    return current;
   });
 
   const progress = useDerivedValue(() => {

--- a/features/tasks/components/AnimatedTabItem.tsx
+++ b/features/tasks/components/AnimatedTabItem.tsx
@@ -2,14 +2,14 @@
 import React from 'react';
 import { TouchableOpacity, type LayoutChangeEvent } from 'react-native';
 import Reanimated, { useAnimatedStyle, useDerivedValue, withTiming, interpolateColor } from 'react-native-reanimated';
-import { TAB_MARGIN_RIGHT, TAB_SWITCH_THRESHOLD } from '../constants';
+import { TAB_MARGIN_RIGHT } from '../constants';
 
 type AnimatedTabItemProps = {
   label: string;
   index: number;
   onPress: (index: number, label: string) => void;
   onTabLayout: (index: number, event: LayoutChangeEvent) => void;
-  pageScrollPosition: Reanimated.SharedValue<number>;
+  selectedTabIndex: number;
   selectedTextColor: string;
   unselectedTextColor: string;
   selectedFontWeight: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | undefined;
@@ -23,7 +23,7 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
   index,
   onPress,
   onTabLayout,
-  pageScrollPosition,
+  selectedTabIndex,
   selectedTextColor,
   unselectedTextColor,
   selectedFontWeight,
@@ -41,10 +41,8 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
   };
 
   const isActive = useDerivedValue(() => {
-    'worklet';
-    const diff = Math.abs(pageScrollPosition.value - index);
-    return diff < TAB_SWITCH_THRESHOLD ? 1 : 0;
-  });
+    return selectedTabIndex === index ? 1 : 0;
+  }, [selectedTabIndex]);
 
   const progress = useDerivedValue(() => {
     'worklet';

--- a/features/tasks/components/AnimatedTabItem.tsx
+++ b/features/tasks/components/AnimatedTabItem.tsx
@@ -2,14 +2,13 @@
 import React from 'react';
 import { TouchableOpacity, type LayoutChangeEvent } from 'react-native';
 import Reanimated, { useAnimatedStyle, useDerivedValue, withTiming, interpolateColor } from 'react-native-reanimated';
-import { TAB_MARGIN_RIGHT, TAB_SWITCH_THRESHOLD } from '../constants';
+import { TAB_MARGIN_RIGHT } from '../constants';
 
 type AnimatedTabItemProps = {
   label: string;
   index: number;
   onPress: (index: number, label: string) => void;
   onTabLayout: (index: number, event: LayoutChangeEvent) => void;
-  pageScrollPosition: Reanimated.SharedValue<number>;
   selectedTabIndexShared: Reanimated.SharedValue<number>;
   selectedTextColor: string;
   unselectedTextColor: string;
@@ -24,7 +23,6 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
   index,
   onPress,
   onTabLayout,
-  pageScrollPosition,
   selectedTabIndexShared,
   selectedTextColor,
   unselectedTextColor,
@@ -42,21 +40,9 @@ export const AnimatedTabItem: React.FC<AnimatedTabItemProps> = React.memo(({
     onTabLayout(index, event);
   };
 
-  const activeIndex = useDerivedValue(() => {
-    'worklet';
-    const current = selectedTabIndexShared.value;
-    const diff = pageScrollPosition.value - current;
-    if (diff >= TAB_SWITCH_THRESHOLD) {
-      return current + 1;
-    } else if (diff <= -TAB_SWITCH_THRESHOLD) {
-      return current - 1;
-    }
-    return current;
-  });
-
   const progress = useDerivedValue(() => {
     'worklet';
-    return withTiming(activeIndex.value === index ? 1 : 0, { duration: 200 });
+    return withTiming(selectedTabIndexShared.value === index ? 1 : 0, { duration: 200 });
   });
 
   const animatedTextStyle = useAnimatedStyle(() => {

--- a/features/tasks/components/FolderTabsBar.tsx
+++ b/features/tasks/components/FolderTabsBar.tsx
@@ -164,7 +164,6 @@ export const FolderTabsBar: React.FC<FolderTabsBarProps> = React.memo(({
               index={index}
               onPress={memoizedOnItemPress}
               onTabLayout={memoizedOnTabLayout}
-              pageScrollPosition={pageScrollPosition}
               selectedTabIndexShared={selectedTabIndexShared}
               selectedTextColor={selectedTextColor}
               unselectedTextColor={unselectedTextColor}

--- a/features/tasks/components/FolderTabsBar.tsx
+++ b/features/tasks/components/FolderTabsBar.tsx
@@ -18,6 +18,7 @@ type FolderTabsBarProps = {
   setFolderTabLayouts: (updater: (prev: Record<number, FolderTabLayout>) => Record<number, FolderTabLayout>) => void;
   handleFolderTabPress: (folderName: string, index: number) => void;
   pageScrollPosition: SharedValue<number>;
+  selectedTabIndexShared: SharedValue<number>;
   folderTabsScrollViewRef: React.RefObject<ScrollView>;
 };
 
@@ -29,6 +30,7 @@ export const FolderTabsBar: React.FC<FolderTabsBarProps> = React.memo(({
   setFolderTabLayouts,
   handleFolderTabPress,
   pageScrollPosition,
+  selectedTabIndexShared,
   folderTabsScrollViewRef,
 }) => {
   const selectedTextColor = styles.folderTabSelectedText.color as string;
@@ -163,6 +165,7 @@ export const FolderTabsBar: React.FC<FolderTabsBarProps> = React.memo(({
               onPress={memoizedOnItemPress}
               onTabLayout={memoizedOnTabLayout}
               pageScrollPosition={pageScrollPosition}
+              selectedTabIndexShared={selectedTabIndexShared}
               selectedTextColor={selectedTextColor}
               unselectedTextColor={unselectedTextColor}
               selectedFontWeight={selectedFontWeight}

--- a/features/tasks/components/FolderTabsBar.tsx
+++ b/features/tasks/components/FolderTabsBar.tsx
@@ -17,6 +17,7 @@ type FolderTabsBarProps = {
   folderTabLayouts: Record<number, FolderTabLayout>;
   setFolderTabLayouts: (updater: (prev: Record<number, FolderTabLayout>) => Record<number, FolderTabLayout>) => void;
   handleFolderTabPress: (folderName: string, index: number) => void;
+  selectedTabIndex: number;
   pageScrollPosition: SharedValue<number>;
   folderTabsScrollViewRef: React.RefObject<ScrollView>;
 };
@@ -28,6 +29,7 @@ export const FolderTabsBar: React.FC<FolderTabsBarProps> = React.memo(({
   folderTabLayouts,
   setFolderTabLayouts,
   handleFolderTabPress,
+  selectedTabIndex,
   pageScrollPosition,
   folderTabsScrollViewRef,
 }) => {
@@ -162,7 +164,7 @@ export const FolderTabsBar: React.FC<FolderTabsBarProps> = React.memo(({
               index={index}
               onPress={memoizedOnItemPress}
               onTabLayout={memoizedOnTabLayout}
-              pageScrollPosition={pageScrollPosition}
+              selectedTabIndex={selectedTabIndex}
               selectedTextColor={selectedTextColor}
               unselectedTextColor={unselectedTextColor}
               selectedFontWeight={selectedFontWeight}

--- a/features/tasks/components/FolderTabsBar.tsx
+++ b/features/tasks/components/FolderTabsBar.tsx
@@ -18,7 +18,6 @@ type FolderTabsBarProps = {
   setFolderTabLayouts: (updater: (prev: Record<number, FolderTabLayout>) => Record<number, FolderTabLayout>) => void;
   handleFolderTabPress: (folderName: string, index: number) => void;
   pageScrollPosition: SharedValue<number>;
-  selectedTabIndexShared: SharedValue<number>;
   folderTabsScrollViewRef: React.RefObject<ScrollView>;
 };
 
@@ -30,7 +29,6 @@ export const FolderTabsBar: React.FC<FolderTabsBarProps> = React.memo(({
   setFolderTabLayouts,
   handleFolderTabPress,
   pageScrollPosition,
-  selectedTabIndexShared,
   folderTabsScrollViewRef,
 }) => {
   const selectedTextColor = styles.folderTabSelectedText.color as string;
@@ -164,7 +162,7 @@ export const FolderTabsBar: React.FC<FolderTabsBarProps> = React.memo(({
               index={index}
               onPress={memoizedOnItemPress}
               onTabLayout={memoizedOnTabLayout}
-              selectedTabIndexShared={selectedTabIndexShared}
+              pageScrollPosition={pageScrollPosition}
               selectedTextColor={selectedTextColor}
               unselectedTextColor={unselectedTextColor}
               selectedFontWeight={selectedFontWeight}

--- a/features/tasks/constants.ts
+++ b/features/tasks/constants.ts
@@ -10,3 +10,4 @@ export const ACCENT_LINE_HEIGHT = 2;
 // fraction of the screen width) before the tab text switches selection state.
 // 0.001 corresponds to 0.1% of the page width.
 export const TAB_SWITCH_THRESHOLD = 0.001;
+

--- a/features/tasks/constants.ts
+++ b/features/tasks/constants.ts
@@ -5,3 +5,8 @@ export const SELECTION_BAR_HEIGHT = 60;
 export const FOLDER_TABS_CONTAINER_PADDING_HORIZONTAL = 12;
 export const TAB_MARGIN_RIGHT = 8;
 export const ACCENT_LINE_HEIGHT = 2;
+// When switching folders by sliding, the text color should update almost
+// immediately. This threshold represents how far the page must move (as a
+// fraction of the screen width) before the tab text switches selection state.
+// 0.001 corresponds to 0.1% of the page width.
+export const TAB_SWITCH_THRESHOLD = 0.001;

--- a/features/tasks/hooks/useTasksScreenLogic.ts
+++ b/features/tasks/hooks/useTasksScreenLogic.ts
@@ -397,10 +397,9 @@ export const useTasksScreenLogic = () => {
       setSelectedTabIndex(index);
       // PagerView をプログラムで操作
       pagerRef.current?.setPage(index);
-      // Accent line と同期させるため即座に値を更新しておく
-      pageScrollPosition.value = withTiming(index, { duration: 250 });
+      // pageScrollPosition は PagerView のスクロールイベントに任せる
     }
-  }, [selectedTabIndex, pageScrollPosition]);
+  }, [selectedTabIndex]);
 
   const handlePageScroll = useCallback((event: PagerViewOnPageScrollEvent) => {
     const { position, offset } = event.nativeEvent;

--- a/features/tasks/hooks/useTasksScreenLogic.ts
+++ b/features/tasks/hooks/useTasksScreenLogic.ts
@@ -53,8 +53,10 @@ export const useTasksScreenLogic = () => {
   
   // ★ ちらつきの原因となっていた currentContentPage を廃止し、新しい確定状態を導入
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const selectedTabIndexShared = useSharedValue(0);
 
   const pageScrollPosition = useSharedValue(0);
+
 
   const noFolderName = useMemo(() => t('common.no_folder_name', 'フォルダなし'), [t]);
 
@@ -139,6 +141,7 @@ export const useTasksScreenLogic = () => {
       // フォルダタブリストが変化したときのみページャーを同期させる
       pagerRef.current?.setPageWithoutAnimation(newIndex);
       pageScrollPosition.value = newIndex;
+      selectedTabIndexShared.value = newIndex;
     }
   }, [folderTabs]);
 
@@ -392,7 +395,9 @@ export const useTasksScreenLogic = () => {
   // ★ タブタップ時の処理を修正
   const handleFolderTabPress = useCallback((_folderName: string, index: number) => {
     if (selectedTabIndex !== index) {
-      // 確定状態を更新
+      // Remember the current index during the animation
+      selectedTabIndexShared.value = selectedTabIndex;
+      // 更新する確定状態
       setSelectedTabIndex(index);
       // PagerView をプログラムで操作
       pagerRef.current?.setPage(index);
@@ -409,12 +414,16 @@ export const useTasksScreenLogic = () => {
   // ★ ページ切り替え完了時の処理を修正
   const handlePageSelected = useCallback((event: PagerViewOnPageSelectedEvent) => {
     const newPageIndex = event.nativeEvent.position;
-    
+
     // 確定状態とUIを同期
     if (selectedTabIndex !== newPageIndex) {
       setSelectedTabIndex(newPageIndex);
     }
-    
+
+    // ページャーからの最終位置を共有値に反映し、差分をゼロにする
+    pageScrollPosition.value = newPageIndex;
+    selectedTabIndexShared.value = newPageIndex;
+
     // 現在のタブを中央にスクロール
     scrollFolderTabsToCenter(newPageIndex);
 
@@ -424,7 +433,7 @@ export const useTasksScreenLogic = () => {
       setSelectedFolderTabName(newSelectedFolder);
       selectionHook.clearSelection();
     }
-  }, [folderTabs, selectedTabIndex, selectionHook, scrollFolderTabsToCenter]);
+  }, [folderTabs, selectedTabIndex, selectionHook, scrollFolderTabsToCenter, pageScrollPosition, selectedTabIndexShared]);
 
   const handleSelectAll = useCallback(() => {
     // ★ 依存を selectedTabIndex に変更
@@ -644,6 +653,7 @@ export const useTasksScreenLogic = () => {
     isReordering, draggingFolder, renameModalVisible, renameTarget,
     selectionAnim, folderTabLayouts, selectedTabIndex, // ★ currentContentPage の代わりに selectedTabIndex を返す
     pageScrollPosition,
+    selectedTabIndexShared,
     noFolderName, folderTabs,
     pagerRef, folderTabsScrollViewRef,
     isSelecting: selectionHook.isSelecting,

--- a/features/tasks/hooks/useTasksScreenLogic.ts
+++ b/features/tasks/hooks/useTasksScreenLogic.ts
@@ -401,10 +401,9 @@ export const useTasksScreenLogic = () => {
       setSelectedTabIndex(index);
       // PagerView をプログラムで操作
       pagerRef.current?.setPage(index);
-      // アニメーション値を更新して、UIの追従を即座に開始させる（ちらつき防止）
-      pageScrollPosition.value = withTiming(index, { duration: 250 });
+      // 実際のスクロールイベントに任せて位置を更新する
     }
-  }, [selectedTabIndex, pageScrollPosition]);
+  }, [selectedTabIndex]);
 
   const handlePageScroll = useCallback((event: PagerViewOnPageScrollEvent) => {
     // PagerViewのスクロールに追従してアニメーション値を更新


### PR DESCRIPTION
## Summary
- let tab highlight change after sliding a tiny amount
- share selected folder tab index with animated items
- add small threshold constant
- keep pager and highlight positions in sync to prevent flicker

## Testing
- `npm run tsc --if-present` *(fails: Unknown env config warning)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68427e15328c8326b3fc64dd1b329653