### PR TITLE
Improve task detail screen design

### DIFF
--- a/features/taskDetail/screens/TaskDetailScreen.tsx
+++ b/features/taskDetail/screens/TaskDetailScreen.tsx
@@ -1,16 +1,13 @@
 // app/(tabs)/task-detail.tsx
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext, useCallback } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
-  StyleSheet,
   ScrollView,
   Image,
   Alert,
-  ViewStyle,
-  TextStyle,
-  ImageStyle,
+  ActivityIndicator,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -18,198 +15,169 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAppTheme } from '@/hooks/ThemeContext';
 import { useTranslation } from 'react-i18next';
-import dayjs from 'dayjs'; // dayjs をインポート
-import type { DeadlineSettings } from '@/features/add/components/DeadlineSettingModal/types'; // DeadlineSettings の型をインポート
+import { FontSizeContext } from '@/context/FontSizeContext';
+import { fontSizes } from '@/constants/fontSizes';
+import dayjs from 'dayjs';
+import type { DeadlineSettings } from '@/features/add/components/DeadlineSettingModal/types';
+import { createStyles } from '../styles';
 
 const STORAGE_KEY = 'TASKS';
 
 type Task = {
   id: string;
   title: string;
-  memo: string;
-  deadline?: string; // deadline はオプショナルに変更
-  imageUris: string[];
-  notifyEnabled: boolean;
-  customUnit: 'minutes' | 'hours' | 'days';
-  customAmount: number;
-  deadlineDetails?: DeadlineSettings; // deadlineDetails プロパティを追加
+  memo?: string;
+  deadline?: string;
+  imageUris?: string[];
+  notifyEnabled?: boolean;
+  customUnit?: 'minutes' | 'hours' | 'days';
+  customAmount?: number;
+  deadlineDetails?: DeadlineSettings;
 };
 
-type TaskDetailStyles = {
-  container: ViewStyle;
-  appBar: ViewStyle;
-  appBarTitle: TextStyle;
-  backButton: ViewStyle;
-  title: TextStyle;
-  label: TextStyle;
-  memo: TextStyle;
-  field: TextStyle;
-  image: ImageStyle;
-  deleteButton: ViewStyle;
-  deleteButtonText: TextStyle;
-};
-
-const createStyles = (isDark: boolean, subColor: string) =>
-  StyleSheet.create<TaskDetailStyles>({
-    container: {
-      flex: 1,
-      backgroundColor: isDark ? '#121212' : '#ffffff',
-    },
-    appBar: {
-      height: 56,
-      paddingHorizontal: 16,
-      flexDirection: 'row',
-      alignItems: 'center',
-      backgroundColor: isDark ? '#121212' : '#ffffff',
-    },
-    appBarTitle: {
-      fontSize: 25,
-      fontWeight: 'bold',
-      color: isDark ? '#fff' : '#000',
-      marginLeft: 16,
-    },
-    backButton: {
-      padding: 8,
-    },
-    title: {
-      fontSize: 24,
-      fontWeight: 'bold',
-      marginBottom: 12,
-      color: isDark ? '#fff' : '#000',
-    },
-    label: {
-      fontSize: 18,
-      fontWeight: '600',
-      marginTop: 16,
-      marginBottom: 4,
-      color: subColor,
-    },
-    memo: {
-      fontSize: 16,
-      color: isDark ? '#ccc' : '#333',
-    },
-    field: {
-      fontSize: 16,
-      color: isDark ? '#ccc' : '#333',
-    },
-    image: {
-      width: '100%',
-      height: 200,
-      borderRadius: 10,
-      marginTop: 10,
-    },
-    deleteButton: {
-      backgroundColor: 'red',
-      marginTop: 30,
-      paddingVertical: 12,
-      borderRadius: 10,
-      alignItems: 'center',
-    },
-    deleteButtonText: {
-      color: '#fff',
-      fontSize: 18,
-      fontWeight: 'bold',
-    },
-  });
-
-  export default function TaskDetailScreen() {
-    const { id } = useLocalSearchParams<{ id: string }>();
-    const router = useRouter();
-    const { colorScheme, subColor } = useAppTheme();
-    const isDark = colorScheme === 'dark';
-    const styles = createStyles(isDark, subColor);
-    const { t, i18n } = useTranslation(); // i18n を追加
-
-    const [task, setTask] = useState<Task | null>(null);
-
-    useEffect(() => {
-      (async () => {
-        const raw = await AsyncStorage.getItem(STORAGE_KEY);
-        if (!raw) return;
-        const list = JSON.parse(raw);
-        const found = list.find((t: Task) => t.id === id);
-        if (found) setTask(found);
-      })();
-    }, [id]);
-
-    const handleDelete = async () => {
-      Alert.alert(
-        t('task_detail.delete_confirm_title'),
-        t('task_detail.delete_confirm'),
-        [
-          { text: t('common.cancel'), style: 'cancel' },
-          {
-            text: t('common.delete'),
-            style: 'destructive',
-            onPress: async () => {
-              try {
-                const raw = await AsyncStorage.getItem(STORAGE_KEY);
-                if (!raw) return;
-                const list = JSON.parse(raw);
-                const updated = list.filter((t: Task) => t.id !== id);
-                await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-                router.replace('/(tabs)/tasks'); // パスを修正 (tasks ディレクトリは通常不要)
-              } catch (error) {
-                console.error('Failed to delete task', error);
-              }
-            },
-          },
-        ]
-      );
+const formatDeadlineForDisplay = (
+  settings: DeadlineSettings | undefined,
+  t: Function,
+  lang: string
+): string => {
+  if (!settings) return t('common.not_set');
+  const {
+    taskDeadlineDate,
+    isTaskDeadlineTimeEnabled,
+    taskDeadlineTime,
+    repeatFrequency,
+    repeatStartDate,
+  } = settings;
+  if (repeatFrequency) {
+    const map: Record<string, string> = {
+      daily: 'deadline_modal.daily',
+      weekly: 'deadline_modal.weekly',
+      monthly: 'deadline_modal.monthly',
+      yearly: 'deadline_modal.yearly',
+      custom: 'deadline_modal.custom',
     };
-
-    if (!task) {
-      return (
-        <SafeAreaView style={styles.container}>
-          <View style={styles.appBar}>
-            <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
-              <Ionicons name="arrow-back" size={24} color={subColor} />
-            </TouchableOpacity>
-            <Text style={styles.appBarTitle}>{t('task_detail.title')}</Text>
-          </View>
-          <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-            <Text style={styles.memo}>{t('common.loading')}</Text>
-          </View>
-        </SafeAreaView>
-      );
+    let text = t(map[repeatFrequency]);
+    if (repeatStartDate) {
+      const d = dayjs(repeatStartDate).format(lang.startsWith('ja') ? 'YYYY/MM/DD' : 'L');
+      text += ` (${d})`;
     }
+    return text;
+  }
+  if (taskDeadlineDate) {
+    let d = dayjs(taskDeadlineDate).format(lang.startsWith('ja') ? 'YYYY/MM/DD' : 'L');
+    if (isTaskDeadlineTimeEnabled && taskDeadlineTime) {
+      d += ` ${String(taskDeadlineTime.hour).padStart(2, '0')}:${String(taskDeadlineTime.minute).padStart(2, '0')}`;
+    }
+    return d;
+  }
+  return t('common.not_set');
+};
 
+export default function TaskDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const { colorScheme, subColor } = useAppTheme();
+  const isDark = colorScheme === 'dark';
+  const { fontSizeKey } = useContext(FontSizeContext);
+  const styles = createStyles(isDark, subColor, fontSizeKey);
+  const { t, i18n } = useTranslation();
+
+  const [task, setTask] = useState<Task | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const raw = await AsyncStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const list = JSON.parse(raw);
+      const found = list.find((t: Task) => t.id === id);
+      if (found) setTask(found);
+    })();
+  }, [id]);
+
+  const handleDelete = useCallback(() => {
+    Alert.alert(t('task_detail.delete_confirm_title'), t('task_detail.delete_confirm'), [
+      { text: t('common.cancel'), style: 'cancel' },
+      {
+        text: t('common.delete'),
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            const raw = await AsyncStorage.getItem(STORAGE_KEY);
+            if (!raw) return;
+            const list = JSON.parse(raw);
+            const updated = list.filter((t: Task) => t.id !== id);
+            await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+            router.replace('/(tabs)/tasks');
+          } catch (e) {
+            console.error('Failed to delete task', e);
+          }
+        },
+      },
+    ]);
+  }, [id, router, t]);
+
+  const handleEdit = useCallback(() => {
+    router.push({ pathname: '/add_edit/index', params: { id } });
+  }, [id, router]);
+
+  if (!task) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
         <View style={styles.appBar}>
-          <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
-            <Ionicons name="arrow-back" size={24} color={subColor} />
+          <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+            <Ionicons name="arrow-back" size={fontSizes[fontSizeKey]} color={subColor} />
           </TouchableOpacity>
           <Text style={styles.appBarTitle}>{t('task_detail.title')}</Text>
+          <View style={styles.appBarActionPlaceholder} />
         </View>
-
-        <ScrollView contentContainerStyle={{ padding: 20 }}>
-          <Text style={styles.title}>{task.title}</Text>
-
-          <Text style={styles.label}>{t('task_detail.memo')}</Text>
-          <Text style={styles.memo}>{task.memo || '-'}</Text>
-
-          <Text style={styles.label}>{t('task_detail.deadline')}</Text>
-          <Text style={styles.field}>
-            {task.deadline ? dayjs(task.deadline).format(i18n.language.startsWith('ja') ? 'YYYY/MM/DD' : 'L') : t('common.not_set')}
-            {task.deadline && task.deadlineDetails?.isTaskDeadlineTimeEnabled ? (
-              ` ${dayjs(task.deadline).format('HH:mm')}`
-            ) : ''}
-          </Text>
-
-          {task.imageUris && task.imageUris.length > 0 && ( // task.imageUris が undefined でないかチェック
-            <>
-              <Text style={styles.label}>{t('task_detail.photo')}</Text>
-              {task.imageUris.map((uri) => (
-                <Image key={uri} source={{ uri }} style={styles.image} />
-              ))}
-            </>
-          )}
-
-          <TouchableOpacity style={styles.deleteButton} onPress={handleDelete}>
-            <Text style={styles.deleteButtonText}>{t('common.delete')}</Text>
-          </TouchableOpacity>
-        </ScrollView>
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <ActivityIndicator size="large" color={subColor} />
+        </View>
       </SafeAreaView>
     );
   }
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
+      <View style={styles.appBar}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <Ionicons name="arrow-back" size={fontSizes[fontSizeKey]} color={subColor} />
+        </TouchableOpacity>
+        <Text style={styles.appBarTitle}>{t('task_detail.title')}</Text>
+        <View style={styles.appBarActionPlaceholder} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.contentContainer}>
+        <Text style={styles.title}>{task.title}</Text>
+
+        {task.memo ? (
+          <>
+            <Text style={styles.label}>{t('task_detail.memo')}</Text>
+            <Text style={styles.memo}>{task.memo}</Text>
+          </>
+        ) : null}
+
+        <Text style={styles.label}>{t('task_detail.deadline')}</Text>
+        <Text style={styles.field}>{formatDeadlineForDisplay(task.deadlineDetails, t, i18n.language)}</Text>
+
+        {task.imageUris && task.imageUris.length > 0 && (
+          <>
+            <Text style={styles.label}>{t('task_detail.photo')}</Text>
+            {task.imageUris.map((uri) => (
+              <Image key={uri} source={{ uri }} style={styles.image} />
+            ))}
+          </>
+        )}
+      </ScrollView>
+
+      <View style={styles.actionRow}>
+        <TouchableOpacity style={styles.editButton} onPress={handleEdit}>
+          <Text style={styles.buttonText}>{t('task_detail.edit')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.deleteButton} onPress={handleDelete}>
+          <Text style={styles.buttonText}>{t('common.delete')}</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/features/taskDetail/styles.ts
+++ b/features/taskDetail/styles.ts
@@ -1,0 +1,115 @@
+import { StyleSheet, ViewStyle, TextStyle, ImageStyle } from 'react-native';
+import { fontSizes } from '@/constants/fontSizes';
+import type { FontSizeKey } from '@/context/FontSizeContext';
+
+export type TaskDetailStyles = {
+  container: ViewStyle;
+  appBar: ViewStyle;
+  appBarTitle: TextStyle;
+  backButton: ViewStyle;
+  appBarActionPlaceholder: ViewStyle;
+  contentContainer: ViewStyle;
+  title: TextStyle;
+  label: TextStyle;
+  memo: TextStyle;
+  field: TextStyle;
+  image: ImageStyle;
+  actionRow: ViewStyle;
+  editButton: ViewStyle;
+  deleteButton: ViewStyle;
+  buttonText: TextStyle;
+};
+
+export const createStyles = (
+  isDark: boolean,
+  subColor: string,
+  fsKey: FontSizeKey
+): TaskDetailStyles =>
+  StyleSheet.create<TaskDetailStyles>({
+    container: {
+      flex: 1,
+      backgroundColor: isDark ? '#000000' : '#F2F2F7',
+    },
+    appBar: {
+      height: 56,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 8,
+      backgroundColor: isDark ? '#000000' : '#F2F2F7',
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: isDark ? '#3A3A3C' : '#D1D1D6',
+    },
+    backButton: {
+      padding: 8,
+    },
+    appBarTitle: {
+      flex: 1,
+      textAlign: 'center',
+      fontSize: fontSizes[fsKey] + 4,
+      fontWeight: '600',
+      color: isDark ? '#FFFFFF' : '#000000',
+    },
+    appBarActionPlaceholder: {
+      width: 32,
+    },
+    contentContainer: {
+      padding: 20,
+    },
+    title: {
+      fontSize: fontSizes[fsKey] + 4,
+      fontWeight: '600',
+      color: isDark ? '#FFFFFF' : '#000000',
+      marginBottom: 12,
+    },
+    label: {
+      fontSize: fontSizes[fsKey],
+      fontWeight: '600',
+      color: subColor,
+      marginBottom: 4,
+      marginTop: 16,
+    },
+    memo: {
+      fontSize: fontSizes[fsKey],
+      color: isDark ? '#E0E0E0' : '#333333',
+    },
+    field: {
+      fontSize: fontSizes[fsKey],
+      color: isDark ? '#E0E0E0' : '#333333',
+    },
+    image: {
+      width: '100%',
+      height: 200,
+      borderRadius: 10,
+      marginTop: 10,
+    },
+    actionRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      paddingHorizontal: 20,
+      marginTop: 24,
+      marginBottom: 20,
+    },
+    editButton: {
+      flex: 1,
+      backgroundColor: subColor,
+      paddingVertical: 12,
+      borderRadius: 10,
+      alignItems: 'center',
+      marginRight: 8,
+    },
+    deleteButton: {
+      flex: 1,
+      backgroundColor: '#FF3B30',
+      paddingVertical: 12,
+      borderRadius: 10,
+      alignItems: 'center',
+      marginLeft: 8,
+    },
+    buttonText: {
+      color: '#FFFFFF',
+      fontSize: fontSizes[fsKey],
+      fontWeight: '600',
+    },
+  });
+

--- a/locales/en.json
+++ b/locales/en.json
@@ -3,8 +3,9 @@
     "title": "Task Details",
     "memo": "Memo",
     "deadline": "Deadline",
-    "photo": "Photo",
-    "delete_confirm_title": "Confirm Deletion",
+  "photo": "Photo",
+  "edit": "Edit",
+  "delete_confirm_title": "Confirm Deletion",
     "delete_confirm": "Are you sure you want to delete this task?"
   },
   "settings": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,9 +1,11 @@
 {
   "task_detail": {
-    "title": "タスク詳細",
-    "memo": "メモ",
-    "photo": "写真",
-    "delete_confirm_title": "削除確認",
+  "title": "タスク詳細",
+  "memo": "メモ",
+  "deadline": "期限",
+  "photo": "写真",
+  "edit": "編集",
+  "delete_confirm_title": "削除確認",
     "delete_confirm": "このタスクを削除しますか？"
   },
   "settings": {

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -2,9 +2,10 @@
   "task_detail": {
     "title": "작업 상세",
     "memo": "메모",
-    "deadline": "마감일",
-    "photo": "사진",
-    "delete_confirm_title": "삭제 확인",
+  "deadline": "마감일",
+  "photo": "사진",
+  "edit": "편집",
+  "delete_confirm_title": "삭제 확인",
     "delete_confirm": "이 작업을 삭제하시겠습니까?"
   },
   "settings": {


### PR DESCRIPTION
## Summary
- redesign task detail screen with theme-aware styles
- add localized edit button and improved action row
- provide new styles for task detail screen

## Testing
- `npm run` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68428a0a20a48326b42b2311f82d300e