### PR TITLE
スマホの言語を初回取得しライトモードで起動

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,7 +7,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import React, { useEffect, useState } from 'react';
 import 'react-native-reanimated';
-import '@/lib/i18n';
+import i18n, { initI18n } from '@/lib/i18n';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import { ThemeProvider, useAppTheme } from '@/hooks/ThemeContext';
@@ -51,12 +51,17 @@ export default function RootLayout() {
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
   const [animationDone, setAnimationDone] = useState(false);
+  const [i18nReady, setI18nReady] = useState(false);
 
   useEffect(() => {
-    if (loaded) SplashScreen.hideAsync();
-  }, [loaded]);
+    initI18n().then(() => setI18nReady(true));
+  }, []);
 
-  if (!loaded) return null;
+  useEffect(() => {
+    if (loaded && i18nReady) SplashScreen.hideAsync();
+  }, [loaded, i18nReady]);
+
+  if (!loaded || !i18nReady) return null;
 
   return (
     <ThemeProvider>

--- a/features/settings/components/LanguageSelector.tsx
+++ b/features/settings/components/LanguageSelector.tsx
@@ -4,14 +4,15 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { useTranslation } from 'react-i18next'
+import { changeAppLanguage } from '@/lib/i18n'
 
 export default function LanguageScreen() {
   const { i18n, t } = useTranslation()
   const router = useRouter()
   const currentLang = i18n.language
 
-  const changeLanguage = (lng: string) => {
-    i18n.changeLanguage(lng)
+  const changeLanguage = async (lng: string) => {
+    await changeAppLanguage(lng)
     router.back()
   }
 

--- a/hooks/ThemeContext.tsx
+++ b/hooks/ThemeContext.tsx
@@ -21,7 +21,7 @@ interface ThemeContextValue {
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
-  themeChoice: 'system',
+  themeChoice: 'light',
   setThemeChoice: () => {},
   colorScheme: 'light',
   subColor: '#4CAF50',
@@ -37,7 +37,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [systemScheme, setSystemScheme] = useState<'light' | 'dark'>(
     () => normalizeScheme(Appearance.getColorScheme())
   )
-  const [themeChoice, setThemeChoiceState] = useState<ThemeChoice>('system')
+  const [themeChoice, setThemeChoiceState] = useState<ThemeChoice>('light')
   const [subColor, setSubColorState] = useState('#4CAF50') // デフォルト緑
 
   useEffect(() => {

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,35 +1,43 @@
-// app/i18n.ts
+// lib/i18n.ts
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import * as Localization from 'expo-localization'
 import en from '../locales/en.json'
 import ja from '../locales/ja.json'
 import ko from '../locales/ko.json'
 
-// 翻訳リソース
+export const LANGUAGE_KEY = 'APP_LANGUAGE'
+
 const resources = {
   en: { translation: en },
   ja: { translation: ja },
   ko: { translation: ko },
 }
-const getInitialLanguage = () => {
+
+async function getInitialLanguage(): Promise<string> {
+  const saved = await AsyncStorage.getItem(LANGUAGE_KEY)
+  if (saved) return saved
   const locale = Localization.locale ?? ''
   if (locale.startsWith('ko')) return 'ko'
   if (locale.startsWith('ja')) return 'ja'
   return 'en'
 }
 
-// i18n初期化
-i18n
-  .use(initReactI18next)
-  .init({
+export async function initI18n() {
+  const lng = await getInitialLanguage()
+  await i18n.use(initReactI18next).init({
     resources,
-    lng: getInitialLanguage(),
+    lng,
     fallbackLng: 'en',
     compatibilityJSON: 'v4',
-    interpolation: {
-      escapeValue: false,
-    },
+    interpolation: { escapeValue: false },
   })
+}
+
+export async function changeAppLanguage(lng: string) {
+  await i18n.changeLanguage(lng)
+  await AsyncStorage.setItem(LANGUAGE_KEY, lng)
+}
 
 export default i18n


### PR DESCRIPTION
## Summary
- set light mode as default when the app is first launched
- persist language choice and change language selector to store it
- initialise i18n asynchronously using saved language or device locale
- wait for i18n initialisation before rendering the app

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842955148548326bef131a750462683