### PR TITLE
Add quick-add button to calendar

### DIFF
--- a/features/add/index.tsx
+++ b/features/add/index.tsx
@@ -112,7 +112,7 @@ export default function AddTaskScreen() {
   const { t, i18n } = useTranslation();
   const navigation = useNavigation<BottomTabNavigationProp<TabParamList>>();
   const router = useRouter();
-  const { draftId } = useLocalSearchParams<{ draftId?: string }>();
+  const { draftId, date } = useLocalSearchParams<{ draftId?: string; date?: string }>();
 
   const unsaved = useUnsavedStore((state) => state.unsaved);
   const setUnsaved = useUnsavedStore((state) => state.setUnsaved);
@@ -142,11 +142,11 @@ export default function AddTaskScreen() {
     memo: '',
     selectedUris: [] as string[],
     folder: '',
-    currentDeadlineSettings: undefined as DeadlineSettings | undefined,
+    currentDeadlineSettings: date ? { taskDeadlineDate: String(date) } as DeadlineSettings : undefined,
     notificationActive: false,
     customAmount: 1,
     customUnit: 'hours' as NotificationUnit,
-  }), []);
+  }), [date]);
 
 
   const [selectedUris, setSelectedUris] = useState<string[]>(initialFormState.selectedUris);

--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -1,7 +1,7 @@
 // app/(tabs)/calendar/index.tsx
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
-import { View, FlatList, Text, ActivityIndicator, Pressable } from 'react-native';
-import { useFocusEffect } from 'expo-router';
+import { View, FlatList, Text, ActivityIndicator, Pressable, TouchableOpacity, Platform } from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Gesture, GestureDetector, Directions } from 'react-native-gesture-handler';
 import { useSharedValue, withTiming, runOnJS } from 'react-native-reanimated';
@@ -19,6 +19,7 @@ import type { Task } from '@/features/tasks/types';
 import { STORAGE_KEY as TASKS_KEY } from '@/features/tasks/constants';
 import { TaskItem } from '@/features/tasks/components/TaskItem';
 import { createCalendarStyles } from '@/features/calendar/styles';
+import { Ionicons } from '@expo/vector-icons';
 const CALENDAR_BG_KEY = '@calendar_background_id';
 const WEEKDAY_COLOR = '#888888';
 const SUNDAY_COLOR = '#FF6666';
@@ -29,6 +30,7 @@ export default function CalendarPage() {
   const { colorScheme, subColor } = useAppTheme();
   const isDark = colorScheme === 'dark';
   const styles = createCalendarStyles(isDark, subColor);
+  const router = useRouter();
 
   const { enabled: googleEnabled } = useGoogleCalendarSync();
 
@@ -179,6 +181,12 @@ export default function CalendarPage() {
         style={styles.list}
         contentContainerStyle={styles.listContent}
       />
+      <TouchableOpacity
+        style={[styles.fab, { bottom: Platform.OS === 'ios' ? 16 : 16 }]}
+        onPress={() => router.push({ pathname: '/add/', params: { date: selectedDate } })}
+      >
+        <Ionicons name="add" size={32} color="#fff" />
+      </TouchableOpacity>
     </SafeAreaView>
   );
 }

--- a/features/calendar/styles.ts
+++ b/features/calendar/styles.ts
@@ -17,11 +17,19 @@ export type CalendarScreenStyles = {
   googleHeaderText: TextStyle;
   googleEventContainer: ViewStyle;
   googleEvent: TextStyle;
+  fab: ViewStyle;
 };
 
 export const createCalendarStyles = (isDark: boolean, subColor: string): CalendarScreenStyles => {
   const textColor = isDark ? '#FFFFFF' : '#000000';
   const dynamicSubColor = subColor || (isDark ? '#4875B7' : '#2F5A8F');
+  const shadowStyle = {
+    shadowColor: isDark ? '#000' : '#555',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: isDark ? 0.25 : 0.1,
+    shadowRadius: 3.84,
+    elevation: 3,
+  };
   
   return StyleSheet.create({
     container: {
@@ -99,6 +107,20 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         fontSize: 14,
         lineHeight: 18,
         color: textColor,
+    },
+    fab: {
+        position: 'absolute',
+        margin: 16,
+        right: 16,
+        bottom: 16,
+        backgroundColor: dynamicSubColor,
+        width: 60,
+        height: 60,
+        borderRadius: 30,
+        justifyContent: 'center',
+        alignItems: 'center',
+        ...shadowStyle,
+        elevation: 6,
     },
   });
 };


### PR DESCRIPTION
## Summary
- enable Add Task screen to prefill a deadline date from the route
- add floating `+` button to the calendar screen
- provide styles for the new calendar FAB

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68429ef183b883269db85f5caf54fea2