### PR TITLE
Implement improved task detail screen

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -3,6 +3,10 @@
     "title": "Task Details",
     "memo": "Memo",
     "photo": "Photo",
+    "deadline": "Deadline",
+    "complete": "Complete",
+    "edit": "Edit",
+    "share": "Share",
     "delete_confirm_title": "Confirm Deletion",
     "delete_confirm": "Are you sure you want to delete this task?"
   },

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -3,6 +3,10 @@
     "title": "タスク詳細",
     "memo": "メモ",
     "photo": "写真",
+    "deadline": "締切",
+    "complete": "完了",
+    "edit": "編集",
+    "share": "共有",
     "delete_confirm_title": "削除確認",
     "delete_confirm": "このタスクを削除しますか？"
   },

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -3,6 +3,10 @@
     "title": "작업 상세",
     "memo": "메모",
     "photo": "사진",
+    "deadline": "마감일",
+    "complete": "완료",
+    "edit": "편집",
+    "share": "공유",
     "delete_confirm_title": "삭제 확인",
     "delete_confirm": "이 작업을 삭제하시겠습니까?"
   },


### PR DESCRIPTION
## Summary
- enhance `TaskDetailScreen` with completion button, countdown, and action buttons
- support viewing images in full size and sharing tasks
- add new translations for task detail labels in en/ja/ko

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842a147ee608326a29844fd9afa43e0