### PR TITLE
Fix header title styles

### DIFF
--- a/features/growth/GrowthScreen.tsx
+++ b/features/growth/GrowthScreen.tsx
@@ -65,8 +65,8 @@ const createStyles = (isDark: boolean, subColor: string, fontSizeKey: string) =>
       borderBottomColor: isDark ? '#3A3A3C' : '#D1D1D6',
     },
     title: {
-      fontSize: baseFont + 2,
-      fontWeight: '600',
+      fontSize: 20,
+      fontWeight: 'bold',
       color: isDark ? '#FFFFFF' : '#000000',
     },
     content: {

--- a/features/settings/SettingsScreen.tsx
+++ b/features/settings/SettingsScreen.tsx
@@ -274,8 +274,8 @@ const createStyles = (
       borderBottomColor: isDark ? '#3A3A3C' : '#C6C6C8',
     },
     appBarTitle: {
-      fontSize: fontSizes[fsKey] + (Platform.OS === 'ios' ? 2 : 1),
-      fontWeight: Platform.OS === 'ios' ? '600' : 'bold',
+      fontSize: 20,
+      fontWeight: 'bold',
       color: isDark ? '#EFEFF0' : '#1C1C1E',
     },
     card: {

--- a/features/taskDetail/screens/TaskDetailScreen.tsx
+++ b/features/taskDetail/screens/TaskDetailScreen.tsx
@@ -71,10 +71,11 @@ const createStyles = (isDark: boolean, subColor: string) =>
       backgroundColor: isDark ? '#121212' : '#ffffff',
     },
     appBarTitle: {
-      fontSize: 25,
+      fontSize: 20,
       fontWeight: 'bold',
       color: isDark ? '#fff' : '#000',
-      marginLeft: 16,
+      flex: 1,
+      textAlign: 'center',
     },
     backButton: { padding: 8 },
     completeButton: { padding: 8 },


### PR DESCRIPTION
## Summary
- unify header title font size and weight across screens
- apply consistent center alignment in task detail screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842a76ad2f0832699168cc26746f24b