### PR TITLE
Add calendar view toggle

### DIFF
--- a/features/calendar/styles.ts
+++ b/features/calendar/styles.ts
@@ -9,6 +9,7 @@ export type CalendarScreenStyles = {
   monthText: TextStyle;
   todayButton: ViewStyle;
   todayButtonText: TextStyle;
+  toggleButton: ViewStyle;
   calendarWrapper: ViewStyle;
   list: ViewStyle;
   listContent: ViewStyle;
@@ -55,7 +56,7 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         alignItems: 'center',
         paddingHorizontal: 12, // 左右の余白を調整
         paddingVertical: 10,
-        backgroundColor: isDark ? '#000000' : '#f2f2f4',
+        backgroundColor: isDark ? '#000000' : '#FFFFFF',
     },
     monthText: {
         fontSize: 22,
@@ -64,6 +65,13 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
     },
     todayButton: {
         paddingHorizontal: 12,
+        paddingVertical: 6,
+        borderRadius: 8,
+        backgroundColor: dynamicSubColor,
+    },
+    toggleButton: {
+        marginLeft: 8,
+        paddingHorizontal: 10,
         paddingVertical: 6,
         borderRadius: 8,
         backgroundColor: dynamicSubColor,


### PR DESCRIPTION
## Summary
- allow switching between list view and full month view on calendar screen
- show task titles inside calendar cells when in full view
- add toggle button and swipe gesture for switching views
- adjust full calendar cell height and tighten margins
- match month header background color with calendar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842c70cdd2083268c623733459f0f7f