### PR TITLE
Fix task detail title alignment

### DIFF
--- a/features/taskDetail/screens/TaskDetailScreen.tsx
+++ b/features/taskDetail/screens/TaskDetailScreen.tsx
@@ -12,6 +12,7 @@ import {
   Modal,
   BackHandler,
   useWindowDimensions,
+  Platform,
   ViewStyle,
   TextStyle,
   ImageStyle,
@@ -80,7 +81,7 @@ const createStyles = (isDark: boolean, subColor: string, fsKey: FontSizeKey) =>
     },
     backButton: { padding: 8, marginRight: 8 },
     appBarActionPlaceholder: {
-      width: 24 + 8,
+      width: (Platform.OS === 'ios' ? 32 : 24) + 8,
     },
     title: {
       fontSize: fontSizes[fsKey] + 8,


### PR DESCRIPTION
## Summary
- center title text in TaskDetail screen by balancing action placeholder width

## Testing
- `npx prettier --write features/taskDetail/screens/TaskDetailScreen.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6842cf7e814c8326a8524ac99c0d5938