### PR TITLE
Fix width alignment of calendar

### DIFF
--- a/features/calendar/components/SkiaCalendar.tsx
+++ b/features/calendar/components/SkiaCalendar.tsx
@@ -12,7 +12,8 @@ import type { Task } from '@/features/tasks/types';
 import type { EventLayout } from '../utils';
 
 const FONT_PATH = require('@/assets/fonts/NotoSansJP-Regular.ttf');
-const PADDING = 0; // 横幅いっぱいに表示するために余白を0に
+// カレンダーコンテナの左右余白と枠線分を考慮したパディング
+const PADDING = 5;
 const HEADER_HEIGHT = 30; // 曜日表示欄を少し細くする
 const TASK_BAR_HEIGHT = 5;
 const TASK_BAR_MARGIN = 3;

--- a/features/calendar/styles.ts
+++ b/features/calendar/styles.ts
@@ -78,7 +78,7 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         backgroundColor: dynamicSubColor,
     },
     calendarContainer: {
-        marginHorizontal: 8,
+        marginHorizontal: 4,
         borderWidth: 1,
         borderColor: isDark ? '#202020' : '#888888',
         borderRadius: 8,


### PR DESCRIPTION
## Summary
- adjust margin for calendar container
- update SkiaCalendar padding to match container width

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842d62edbf48326bb52db6f37a18035