### PR TITLE
Fix full calendar display

### DIFF
--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -154,7 +154,10 @@ export default function CalendarPage() {
        <View style={styles.appBar}>
          <Text style={styles.titleText}>{t('calendar.title')}</Text>
        </View>
-      <View style={styles.calendarContainer}>
+      <View style={[
+        styles.calendarContainer,
+        viewType === 'full' && styles.fullCalendarContainer,
+      ]}>
         <View style={styles.monthHeader}>
              <Text style={styles.monthText}>
                  {displayMonth.format(t('common.year_month_format'))}

--- a/features/calendar/styles.ts
+++ b/features/calendar/styles.ts
@@ -20,6 +20,7 @@ export type CalendarScreenStyles = {
   googleEventContainer: ViewStyle;
   googleEvent: TextStyle;
   fab: ViewStyle;
+  fullCalendarContainer: ViewStyle;
 };
 
 export const createCalendarStyles = (isDark: boolean, subColor: string): CalendarScreenStyles => {
@@ -137,6 +138,13 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         alignItems: 'center',
         ...shadowStyle,
         elevation: 6,
+    },
+    fullCalendarContainer: {
+        marginHorizontal: 0,
+        borderWidth: 0,
+        borderRadius: 0,
+        overflow: 'visible',
+        flex: 1,
     },
   });
 };


### PR DESCRIPTION
## Summary
- adjust calendar styles so full screen calendar isn't clipped
- expand calendar container when in full view

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842d8dacb8c83268921d735c310e2ea