### PR TITLE
Refactor modals to share common wrapper

### DIFF
--- a/components/modals/AppModal.tsx
+++ b/components/modals/AppModal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { KeyboardAvoidingView, Platform, StyleProp, ViewStyle } from 'react-native';
+import Modal from 'react-native-modal';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+interface AppModalProps {
+  visible: boolean;
+  onClose: () => void;
+  style?: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+}
+
+const BACKDROP_OPACITY = 0.4;
+const ANIMATION_TIMING = 250;
+
+export const AppModal: React.FC<AppModalProps> = ({ visible, onClose, style, children }) => (
+  <Modal
+    isVisible={visible}
+    onBackdropPress={onClose}
+    onBackButtonPress={onClose}
+    style={[{ justifyContent: 'flex-end', margin: 0 }, style]}
+    animationIn="slideInUp"
+    animationOut="slideOutDown"
+    animationInTiming={ANIMATION_TIMING}
+    animationOutTiming={ANIMATION_TIMING}
+    backdropTransitionInTiming={ANIMATION_TIMING}
+    backdropTransitionOutTiming={ANIMATION_TIMING}
+    useNativeDriver
+    useNativeDriverForBackdrop
+    backdropColor="#000000"
+    backdropOpacity={BACKDROP_OPACITY}
+    hideModalContentWhileAnimating
+  >
+    <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1, justifyContent: 'flex-end' }}>
+      <SafeAreaView edges={['bottom']}>{children}</SafeAreaView>
+    </KeyboardAvoidingView>
+  </Modal>
+);

--- a/components/modals/CustomIntervalModal.tsx
+++ b/components/modals/CustomIntervalModal.tsx
@@ -1,19 +1,16 @@
 // app/features/add/components/DeadlineSettingModal/CustomIntervalModal.tsx
 import React, { useState, useEffect, useMemo, useCallback, useContext } from 'react';
-import { View, Text, TouchableOpacity, TextInput, Platform, StyleSheet, KeyboardAvoidingView } from 'react-native';
-import Modal from 'react-native-modal';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { View, Text, TouchableOpacity, TextInput, Platform, StyleSheet } from 'react-native';
+import { AppModal } from './AppModal';
 import { useTranslation } from 'react-i18next';
 import WheelPicker from 'react-native-wheely';
 
 import { useAppTheme } from '@/hooks/ThemeContext';
 import { FontSizeContext, type FontSizeKey } from '@/context/FontSizeContext';
 import { fontSizes as appFontSizes } from '@/constants/fontSizes';
-import type { CustomIntervalUnit } from './types';
-import type { DeadlineModalStyles } from './types';
+import type { CustomIntervalUnit } from '@/features/add/components/DeadlineSettingModal/types';
+import type { DeadlineModalStyles } from '@/features/add/components/DeadlineSettingModal/types';
 
-const ANIMATION_TIMING = 250;
-const BACKDROP_OPACITY = 0.4;
 
 const WHEELY_ITEM_HEIGHT = Platform.OS === 'ios' ? 40 : 50;
 const BASE_PICKER_FONT_SIZE_INCREASE = 2;
@@ -80,28 +77,8 @@ export const CustomIntervalModal: React.FC<CustomIntervalModalProps> = ({
 
 
   return (
-    <Modal
-      isVisible={visible}
-      onBackdropPress={onClose}
-      onBackButtonPress={onClose}
-      style={styles.modal}
-      animationIn="slideInUp"
-      animationOut="slideOutDown"
-      animationInTiming={ANIMATION_TIMING}
-      animationOutTiming={ANIMATION_TIMING}
-      backdropTransitionInTiming={ANIMATION_TIMING}
-      backdropTransitionOutTiming={ANIMATION_TIMING}
-      useNativeDriver={true}
-      useNativeDriverForBackdrop={true}
-      backdropColor="#000000"
-      backdropOpacity={BACKDROP_OPACITY}
-      hideModalContentWhileAnimating
-    >
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        style={{ justifyContent: 'flex-end', flex:1 }}
-      >
-        <SafeAreaView edges={['bottom']} style={[styles.timePickerModalContainer, styles.customIntervalModalContainer]}>
+    <AppModal visible={visible} onClose={onClose} style={styles.modal}>
+      <View style={[styles.timePickerModalContainer, styles.customIntervalModalContainer]}>
           <View style={styles.headerContainer}>
             <Text style={styles.headerText}>{t('deadline_modal.set_custom_interval')}</Text>
           </View>
@@ -158,8 +135,7 @@ export const CustomIntervalModal: React.FC<CustomIntervalModalProps> = ({
               </Text>
             </TouchableOpacity>
           </View>
-        </SafeAreaView>
-      </KeyboardAvoidingView>
-    </Modal>
+      </View>
+    </AppModal>
   );
 };

--- a/features/add/components/DeadlineSettingModal/RepeatTab.tsx
+++ b/features/add/components/DeadlineSettingModal/RepeatTab.tsx
@@ -20,7 +20,7 @@ import type {
 } from './types';
 import { DatePickerModal } from './DatePickerModal';
 // import { TimePickerModal } from './TimePickerModal'; // 廃止のためコメントアウト
-import { CustomIntervalModal } from './CustomIntervalModal';
+import { CustomIntervalModal } from '@/components/modals/CustomIntervalModal';
 
 
 const todayString = CalendarUtils.getCalendarDateString(new Date());

--- a/features/add/components/FolderSelectorModal.tsx
+++ b/features/add/components/FolderSelectorModal.tsx
@@ -1,12 +1,6 @@
 import React, { useContext, useState, useEffect } from 'react';
-import {
-  Modal,
-  View,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  ScrollView,
-} from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, ScrollView } from 'react-native';
+import { AppModal } from '@/components/modals/AppModal';
 import { useAppTheme } from '@/hooks/ThemeContext';
 import { useTranslation } from 'react-i18next';
 import { FontSizeContext } from '@/context/FontSizeContext';
@@ -55,11 +49,10 @@ export function FolderSelectorModal({
   };
 
   return (
-    <Modal visible={visible} transparent animationType="fade">
+    <AppModal visible={visible} onClose={onClose}>
       <View
         style={{
           flex: 1,
-          backgroundColor: 'rgba(0,0,0,0.5)',
           justifyContent: 'center',
           alignItems: 'center',
           padding: 20,
@@ -263,6 +256,6 @@ export function FolderSelectorModal({
           </View>
         </View>
       </View>
-    </Modal>
+    </AppModal>
   );
 }


### PR DESCRIPTION
## Summary
- move `CustomIntervalModal` to `components/modals`
- add reusable `AppModal` wrapper using the same configuration as `CustomIntervalModal`
- update `RepeatTab` and `FolderSelectorModal` to use the new wrapper

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842d9c4eeb48326b9acc0b9a7a03a64