### PR TITLE
Implement custom dialog provider

### DIFF
--- a/app/(tabs)/drafts.tsx
+++ b/app/(tabs)/drafts.tsx
@@ -109,14 +109,14 @@ const createStyles = (isDark: boolean, subColor: string) =>
     }, []);
   
     const deleteDraft = useCallback(async (id: string) => {
-      const confirmed = await showDialog({
+      const result = await showDialog({
         title: t('draft_list.delete_confirm_title'),
         message: t('draft_list.delete_confirm_message'),
         okText: t('common.delete'),
         cancelText: t('common.cancel'),
         isOkDestructive: true,
       });
-      if (confirmed) {
+      if (result === 'ok') {
         try {
           const updated = drafts.filter((draft) => draft.id !== id);
           await AsyncStorage.setItem(DRAFTS_KEY, JSON.stringify(updated));

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,6 +13,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ThemeProvider, useAppTheme } from '@/hooks/ThemeContext';
 import { FontSizeProvider } from '@/context/FontSizeContext';
 import { GoogleCalendarProvider } from '@/context/GoogleCalendarContext';
+import { DialogProvider } from '@/context/DialogContext';
 import Toast from 'react-native-toast-message';
 import StartupAnimation from '@/components/StartupAnimation';
 
@@ -67,10 +68,12 @@ export default function RootLayout() {
     <ThemeProvider>
       <FontSizeProvider>
         <GoogleCalendarProvider>
-          <InnerLayout />
-          {!animationDone && (
-            <StartupAnimation onAnimationEnd={() => setAnimationDone(true)} />
-          )}
+          <DialogProvider>
+            <InnerLayout />
+            {!animationDone && (
+              <StartupAnimation onAnimationEnd={() => setAnimationDone(true)} />
+            )}
+          </DialogProvider>
         </GoogleCalendarProvider>
       </FontSizeProvider>
     </ThemeProvider>

--- a/components/CustomTabButton.tsx
+++ b/components/CustomTabButton.tsx
@@ -16,14 +16,14 @@ export function CustomTabButton({ to, children, shouldWarn, onDiscard }: Props) 
 
   const handlePress = async () => {
     if (shouldWarn) {
-      const confirmed = await showDialog({
+      const result = await showDialog({
         title: '変更を破棄しますか？',
         message: '保存されていない内容は失われます。',
         okText: '破棄',
         cancelText: 'キャンセル',
         isOkDestructive: true,
       });
-      if (confirmed) {
+      if (result === 'ok') {
         onDiscard();
         router.replace(to);
       }

--- a/components/CustomTabButton.tsx
+++ b/components/CustomTabButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Alert, TouchableOpacity } from 'react-native';
+import { TouchableOpacity } from 'react-native';
+import { useDialog } from '@/context/DialogContext';
 import { useRouter } from 'expo-router';
 
 type Props = {
@@ -11,20 +12,21 @@ type Props = {
 
 export function CustomTabButton({ to, children, shouldWarn, onDiscard }: Props) {
   const router = useRouter();
+  const { showDialog } = useDialog();
 
-  const handlePress = () => {
+  const handlePress = async () => {
     if (shouldWarn) {
-      Alert.alert('変更を破棄しますか？', '保存されていない内容は失われます。', [
-        { text: 'キャンセル', style: 'cancel' },
-        {
-          text: '破棄',
-          style: 'destructive',
-          onPress: () => {
-            onDiscard();
-            router.replace(to);
-          },
-        },
-      ]);
+      const confirmed = await showDialog({
+        title: '変更を破棄しますか？',
+        message: '保存されていない内容は失われます。',
+        okText: '破棄',
+        cancelText: 'キャンセル',
+        isOkDestructive: true,
+      });
+      if (confirmed) {
+        onDiscard();
+        router.replace(to);
+      }
     } else {
       router.replace(to);
     }

--- a/context/DialogContext.tsx
+++ b/context/DialogContext.tsx
@@ -1,0 +1,64 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { ConfirmModal } from '@/features/add/components/DeadlineSettingModal/ConfirmModal';
+
+export type DialogOptions = {
+  title?: string;
+  message: string;
+  okText?: string;
+  cancelText?: string;
+  isOkDestructive?: boolean;
+};
+
+export type DialogContextType = {
+  showDialog: (options: DialogOptions) => Promise<boolean>;
+};
+
+const DialogContext = createContext<DialogContextType | undefined>(undefined);
+
+export const DialogProvider = ({ children }: { children: ReactNode }) => {
+  const [options, setOptions] = useState<DialogOptions | null>(null);
+  const [resolver, setResolver] = useState<((result: boolean) => void) | null>(null);
+
+  const showDialog = (opts: DialogOptions) => {
+    return new Promise<boolean>((resolve) => {
+      setOptions(opts);
+      setResolver(() => resolve);
+    });
+  };
+
+  const handleConfirm = () => {
+    resolver?.(true);
+    setResolver(null);
+    setOptions(null);
+  };
+
+  const handleCancel = () => {
+    resolver?.(false);
+    setResolver(null);
+    setOptions(null);
+  };
+
+  return (
+    <DialogContext.Provider value={{ showDialog }}>
+      {children}
+      {options && (
+        <ConfirmModal
+          visible={true}
+          title={options.title}
+          message={options.message}
+          okText={options.okText}
+          cancelText={options.cancelText}
+          isOkDestructive={options.isOkDestructive}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
+    </DialogContext.Provider>
+  );
+};
+
+export const useDialog = () => {
+  const ctx = useContext(DialogContext);
+  if (!ctx) throw new Error('useDialog must be used within DialogProvider');
+  return ctx;
+};

--- a/context/DialogContext.tsx
+++ b/context/DialogContext.tsx
@@ -6,34 +6,44 @@ export type DialogOptions = {
   message: string;
   okText?: string;
   cancelText?: string;
+  neutralText?: string;
   isOkDestructive?: boolean;
+  isNeutralDestructive?: boolean;
 };
 
+export type DialogResult = 'ok' | 'cancel' | 'neutral';
+
 export type DialogContextType = {
-  showDialog: (options: DialogOptions) => Promise<boolean>;
+  showDialog: (options: DialogOptions) => Promise<DialogResult>;
 };
 
 const DialogContext = createContext<DialogContextType | undefined>(undefined);
 
 export const DialogProvider = ({ children }: { children: ReactNode }) => {
   const [options, setOptions] = useState<DialogOptions | null>(null);
-  const [resolver, setResolver] = useState<((result: boolean) => void) | null>(null);
+  const [resolver, setResolver] = useState<((result: DialogResult) => void) | null>(null);
 
   const showDialog = (opts: DialogOptions) => {
-    return new Promise<boolean>((resolve) => {
+    return new Promise<DialogResult>((resolve) => {
       setOptions(opts);
       setResolver(() => resolve);
     });
   };
 
   const handleConfirm = () => {
-    resolver?.(true);
+    resolver?.('ok');
     setResolver(null);
     setOptions(null);
   };
 
   const handleCancel = () => {
-    resolver?.(false);
+    resolver?.('cancel');
+    setResolver(null);
+    setOptions(null);
+  };
+
+  const handleNeutral = () => {
+    resolver?.('neutral');
     setResolver(null);
     setOptions(null);
   };
@@ -48,9 +58,12 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
           message={options.message}
           okText={options.okText}
           cancelText={options.cancelText}
+          neutralText={options.neutralText}
           isOkDestructive={options.isOkDestructive}
+          isNeutralDestructive={options.isNeutralDestructive}
           onConfirm={handleConfirm}
           onCancel={handleCancel}
+          onNeutral={handleNeutral}
         />
       )}
     </DialogContext.Provider>

--- a/features/add/components/DeadlineSettingModal/ConfirmModal.tsx
+++ b/features/add/components/DeadlineSettingModal/ConfirmModal.tsx
@@ -12,9 +12,12 @@ export type ConfirmModalProps = {
   message: string;
   okText?: string;
   cancelText?: string;
+  neutralText?: string;
   onConfirm: () => void;
   onCancel: () => void;
+  onNeutral?: () => void;
   isOkDestructive?: boolean;
+  isNeutralDestructive?: boolean;
 };
 
 const createConfirmModalStyles = (isDark: boolean, subColor: string, baseFontSize: number) => {
@@ -106,6 +109,8 @@ export function ConfirmModal({
 
   const displayTitle = title ?? t('common.notification_title');
   const hasCancelButton = !!(cancelText && onCancel);
+  const hasNeutralButton = !!(neutralText && onNeutral);
+  const multipleButtons = hasCancelButton || hasNeutralButton;
 
   return (
     <Modal
@@ -130,10 +135,12 @@ export function ConfirmModal({
           <Text style={styles.message}>
             {message}
           </Text>
-          <View style={[
-            styles.buttonContainer,
-            hasCancelButton ? { justifyContent: 'space-between' } : { justifyContent: 'flex-end' }
-          ]}>
+          <View
+            style={[
+              styles.buttonContainer,
+              multipleButtons ? { justifyContent: 'space-between' } : { justifyContent: 'flex-end' },
+            ]}
+          >
             {hasCancelButton && (
               <TouchableOpacity onPress={onCancel} style={styles.actionButton}>
                 <Text style={[styles.buttonText, styles.cancelButtonTextContent]}>
@@ -141,14 +148,25 @@ export function ConfirmModal({
                 </Text>
               </TouchableOpacity>
             )}
-            <TouchableOpacity
-              onPress={onConfirm}
-              style={styles.actionButton}
-            >
-              <Text style={[
-                styles.buttonText,
-                isOkDestructive ? styles.okDestructiveButtonTextContent : styles.okButtonTextContent
-              ]}>
+            {hasNeutralButton && (
+              <TouchableOpacity onPress={onNeutral} style={styles.actionButton}>
+                <Text
+                  style={[
+                    styles.buttonText,
+                    isNeutralDestructive ? styles.okDestructiveButtonTextContent : styles.okButtonTextContent,
+                  ]}
+                >
+                  {neutralText}
+                </Text>
+              </TouchableOpacity>
+            )}
+            <TouchableOpacity onPress={onConfirm} style={styles.actionButton}>
+              <Text
+                style={[
+                  styles.buttonText,
+                  isOkDestructive ? styles.okDestructiveButtonTextContent : styles.okButtonTextContent,
+                ]}
+              >
                 {okText ?? t('common.ok')}
               </Text>
             </TouchableOpacity>

--- a/features/add/components/PhotoPicker.tsx
+++ b/features/add/components/PhotoPicker.tsx
@@ -99,13 +99,13 @@ export const PhotoPicker: React.FC<PhotoPickerProps> = ({
             } else {
               console.log('Permission denied.');
               setGranted(false);
-              const confirmed = await showDialog({
+              const result = await showDialog({
                 title: '権限が必要です',
                 message: '写真や動画にアクセスするためには許可が必要です。設定画面から許可してください。',
                 okText: '設定を開く',
                 cancelText: 'キャンセル',
               });
-              if (confirmed) {
+              if (result === 'ok') {
                 Linking.openSettings().finally(onCancel);
               } else {
                 onCancel();

--- a/features/add/hooks/useSaveTask.ts
+++ b/features/add/hooks/useSaveTask.ts
@@ -1,6 +1,6 @@
 // app/features/add/hooks/useSaveTask.ts
 import { useCallback } from 'react';
-import { Alert } from 'react-native';
+import { useDialog } from '@/context/DialogContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import uuid from 'react-native-uuid';
 import Toast from 'react-native-toast-message';
@@ -86,10 +86,14 @@ export const useSaveTask = ({
   deadlineDetails,
 }: SaveTaskParams) => {
   const router = useRouter();
+  const { showDialog } = useDialog();
 
   const saveTask = useCallback(async () => {
     if (!title.trim()) {
-      Alert.alert(t('add_task.alert_no_title'));
+      await showDialog({
+        message: t('add_task.alert_no_title'),
+        okText: 'OK',
+      });
       return;
     }
     const taskId = uuid.v4() as string;
@@ -149,7 +153,10 @@ export const useSaveTask = ({
 
   const saveDraft = useCallback(async () => {
     if (!title.trim()) {
-      Alert.alert(t('add_task.alert_no_title'));
+      await showDialog({
+        message: t('add_task.alert_no_title'),
+        okText: 'OK',
+      });
       return;
     }
     const id = currentDraftId || (uuid.v4() as string);

--- a/features/add/hooks/useUpdateTask.ts
+++ b/features/add/hooks/useUpdateTask.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Alert } from 'react-native';
+import { useDialog } from '@/context/DialogContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Toast from 'react-native-toast-message';
 import { useRouter } from 'expo-router';
@@ -66,10 +66,11 @@ export const useUpdateTask = ({
   deadlineDetails,
 }: UpdateTaskParams) => {
   const router = useRouter();
+  const { showDialog } = useDialog();
 
   const updateTask = useCallback(async () => {
     if (!title.trim()) {
-      Alert.alert(t('edit_task.alert_no_title'));
+      await showDialog({ message: t('edit_task.alert_no_title'), okText: 'OK' });
       return;
     }
     try {

--- a/features/add/index.tsx
+++ b/features/add/index.tsx
@@ -226,14 +226,14 @@ export default function AddTaskScreen() {
       }
       e.preventDefault();
       (async () => {
-        const confirmed = await showDialog({
+        const result = await showDialog({
           title: t('add_task.alert_discard_changes_title'),
           message: t('add_task.alert_discard_changes_message'),
           okText: t('add_task.alert_discard'),
           cancelText: t('common.cancel'),
           isOkDestructive: true,
         });
-        if (confirmed) {
+        if (result === 'ok') {
           clearForm();
           if (e.data?.action) navigation.dispatch(e.data.action);
           else router.back();

--- a/features/add_edit/screens/EditDraftScreen.tsx
+++ b/features/add_edit/screens/EditDraftScreen.tsx
@@ -338,14 +338,14 @@ export default function EditDraftScreen() {
       if (!title && !memo && imageUris.length === 0) return;
       e.preventDefault();
       (async () => {
-        const confirmed = await showDialog({
+        const result = await showDialog({
           title: t('edit_draft.alert_discard_changes_title'),
           message: t('edit_draft.alert_discard_changes_message'),
           okText: t('edit_draft.alert_discard'),
           cancelText: t('common.cancel'),
           isOkDestructive: true,
         });
-        if (confirmed) {
+        if (result === 'ok') {
           resetUnsaved();
           router.replace('/(tabs)/drafts');
         }

--- a/features/add_edit/screens/EditTaskScreen.tsx
+++ b/features/add_edit/screens/EditTaskScreen.tsx
@@ -123,14 +123,14 @@ export default function EditTaskScreen() {
       if (!unsaved) return;
       e.preventDefault();
       (async () => {
-        const confirmed = await showDialog({
+        const result = await showDialog({
           title: t('edit_task.alert_discard_changes_title'),
           message: t('edit_task.alert_discard_changes_message'),
           okText: t('edit_task.alert_discard'),
           cancelText: t('common.cancel'),
           isOkDestructive: true,
         });
-        if (confirmed) {
+        if (result === 'ok') {
           resetUnsaved();
           if (e.data?.action) navigation.dispatch(e.data.action); else router.back();
         }

--- a/features/settings/SettingsScreen.tsx
+++ b/features/settings/SettingsScreen.tsx
@@ -9,12 +9,12 @@ import {
   useWindowDimensions,
   Platform,
   Image,
-  Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppTheme, ThemeChoice } from '@/hooks/ThemeContext';
 import { useRouter, useFocusEffect } from 'expo-router'; // ← インポートされます
 import { useTranslation } from 'react-i18next';
+import { useDialog } from '@/context/DialogContext';
 import i18n from '@/lib/i18n';
 import Slider from '@react-native-community/slider'; // ← インポートされます
 import { FontSizeContext, FontSizeKey } from '@/context/FontSizeContext';
@@ -36,6 +36,7 @@ export default function SettingsScreen() {
   } = useAppTheme();
   const { fontSizeKey, setFontSizeKey } = useContext(FontSizeContext);
   const { t } = useTranslation();
+  const { showDialog } = useDialog();
   const router = useRouter();
   const isDark = colorScheme === 'dark';
   const { width } = useWindowDimensions();
@@ -225,16 +226,16 @@ export default function SettingsScreen() {
           <Text style={styles.label}>{t('settings.google_calendar_integration', 'Googleカレンダー連携')}</Text>
           <TouchableOpacity
             style={styles.optionRowButton}
-            onPress={() => {
+            onPress={async () => {
               if (isSignedIn) {
-                Alert.alert(
-                  t('settings.google_calendar_integration', 'Googleカレンダー連携'),
-                  t('settings.disconnect_confirm', '連携を解除しますか？'),
-                  [
-                    { text: t('common.cancel', 'キャンセル'), style: 'cancel' },
-                    { text: t('common.ok', 'OK'), onPress: signOut },
-                  ]
-                );
+                const confirmed = await showDialog({
+                  title: t('settings.google_calendar_integration', 'Googleカレンダー連携'),
+                  message: t('settings.disconnect_confirm', '連携を解除しますか？'),
+                  okText: t('common.ok', 'OK'),
+                  cancelText: t('common.cancel', 'キャンセル'),
+                  isOkDestructive: true,
+                });
+                if (confirmed) signOut();
               } else {
                 signIn();
               }

--- a/features/settings/SettingsScreen.tsx
+++ b/features/settings/SettingsScreen.tsx
@@ -228,14 +228,14 @@ export default function SettingsScreen() {
             style={styles.optionRowButton}
             onPress={async () => {
               if (isSignedIn) {
-                const confirmed = await showDialog({
+                const result = await showDialog({
                   title: t('settings.google_calendar_integration', 'Googleカレンダー連携'),
                   message: t('settings.disconnect_confirm', '連携を解除しますか？'),
                   okText: t('common.ok', 'OK'),
                   cancelText: t('common.cancel', 'キャンセル'),
                   isOkDestructive: true,
                 });
-                if (confirmed) signOut();
+                if (result === 'ok') signOut();
               } else {
                 signIn();
               }

--- a/features/taskDetail/screens/TaskDetailScreen.tsx
+++ b/features/taskDetail/screens/TaskDetailScreen.tsx
@@ -175,14 +175,14 @@ const createStyles = (isDark: boolean, subColor: string, fsKey: FontSizeKey) =>
   const { showDialog } = useDialog();
 
   const handleDelete = async () => {
-    const confirmed = await showDialog({
+    const result = await showDialog({
       title: t('task_detail.delete_confirm_title'),
       message: t('task_detail.delete_confirm'),
       okText: t('common.delete'),
       cancelText: t('common.cancel'),
       isOkDestructive: true,
     });
-    if (confirmed) {
+    if (result === 'ok') {
       try {
         const raw = await AsyncStorage.getItem(STORAGE_KEY);
         if (!raw) return;

--- a/features/tasks/hooks/useTasksScreenLogic.ts
+++ b/features/tasks/hooks/useTasksScreenLogic.ts
@@ -553,27 +553,28 @@ export const useTasksScreenLogic = () => {
             title = t('task_list.delete_folder_and_selected_tasks_title', {folderName: folderToDelete.id, count: selectedTasksCount});
         }
 
-        const action = await showDialog({
+        const result = await showDialog({
             title,
             message: t('task_list.delete_folder_confirmation'),
             okText: t('task_list.delete_folder_and_tasks'),
-            cancelText: t('task_list.delete_folder_only'),
+            neutralText: t('task_list.delete_folder_only'),
+            cancelText: t('common.cancel'),
             isOkDestructive: true,
         });
-        if (action) {
+        if (result === 'ok') {
             confirmDelete('delete_all');
-        } else {
+        } else if (result === 'neutral') {
             confirmDelete('only_folder');
         }
     } else if (selectedTasksCount > 0) {
-        const confirmed = await showDialog({
+        const result = await showDialog({
             title: t('task_list.delete_tasks_title', {count: selectedTasksCount}),
             message: t('task_list.delete_tasks_confirmation', {count: selectedTasksCount}),
             okText: t('common.delete'),
             cancelText: t('common.cancel'),
             isOkDestructive: true,
         });
-        if (confirmed) {
+        if (result === 'ok') {
             confirmDelete('delete_tasks_only');
         }
     }


### PR DESCRIPTION
## Summary
- add `DialogProvider` that shows the same dialog used in deadline settings
- wrap the whole app with this provider
- convert `CustomTabButton` to use the new dialog
- use the dialog for deleting drafts

## Testing
- `npm run test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot use JSX without flag and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842e05ef6408326ba18e9f0f9bb8b40