### PR TITLE
カレンダー画面のレイアウト調整

### DIFF
--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -158,7 +158,7 @@ export default function CalendarPage() {
         styles.calendarContainer,
         viewType === 'full' && styles.fullCalendarContainer,
       ]}>
-        <View style={styles.monthHeader}>
+        <View style={[styles.monthHeader, viewType === 'list' && styles.monthHeaderSmall]}>
              <Text style={styles.monthText}>
                  {displayMonth.format(t('common.year_month_format'))}
              </Text>

--- a/features/calendar/components/SkiaCalendar.tsx
+++ b/features/calendar/components/SkiaCalendar.tsx
@@ -13,7 +13,7 @@ import type { EventLayout } from '../utils';
 
 const FONT_PATH = require('@/assets/fonts/NotoSansJP-Regular.ttf');
 // カレンダーコンテナの左右余白と枠線分を考慮したパディング
-const PADDING = 5;
+const PADDING = 12;
 const HEADER_HEIGHT = 30; // 曜日表示欄を少し細くする
 const TASK_BAR_HEIGHT = 5;
 const TASK_BAR_MARGIN = 3;

--- a/features/calendar/styles.ts
+++ b/features/calendar/styles.ts
@@ -79,11 +79,10 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         backgroundColor: dynamicSubColor,
     },
     calendarContainer: {
-        marginHorizontal: 4,
-        borderWidth: 1,
-        borderColor: isDark ? '#202020' : '#888888',
-        borderRadius: 8,
-        overflow: 'hidden',
+        marginHorizontal: 0,
+        borderWidth: 0,
+        borderRadius: 0,
+        overflow: 'visible',
     },
     todayButtonText: {
         fontWeight: 'bold',
@@ -140,7 +139,7 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         elevation: 6,
     },
     fullCalendarContainer: {
-        marginHorizontal: 0,
+        marginHorizontal: 5,
         borderWidth: 0,
         borderRadius: 0,
         overflow: 'visible',

--- a/features/calendar/styles.ts
+++ b/features/calendar/styles.ts
@@ -83,7 +83,7 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         backgroundColor: dynamicSubColor,
     },
     calendarContainer: {
-        marginHorizontal: 5,
+        marginHorizontal: 12,
         borderWidth: 0,
         borderRadius: 0,
         overflow: 'visible',
@@ -144,7 +144,7 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         elevation: 6,
     },
     fullCalendarContainer: {
-        marginHorizontal: 5,
+        marginHorizontal: 12,
         borderWidth: 0,
         borderRadius: 0,
         overflow: 'visible',

--- a/features/calendar/styles.ts
+++ b/features/calendar/styles.ts
@@ -6,6 +6,7 @@ export type CalendarScreenStyles = {
   appBar: ViewStyle;
   titleText: TextStyle;
   monthHeader: ViewStyle;
+  monthHeaderSmall: ViewStyle;
   monthText: TextStyle;
   todayButton: ViewStyle;
   todayButtonText: TextStyle;
@@ -59,6 +60,9 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         paddingHorizontal: 12, // 左右の余白を調整
         paddingVertical: 8,
         backgroundColor: isDark ? '#000000' : '#FFFFFF',
+    },
+    monthHeaderSmall: {
+        backgroundColor: 'transparent',
     },
     monthText: {
         fontSize: 22,

--- a/features/calendar/styles.ts
+++ b/features/calendar/styles.ts
@@ -79,7 +79,7 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         backgroundColor: dynamicSubColor,
     },
     calendarContainer: {
-        marginHorizontal: 0,
+        marginHorizontal: 5,
         borderWidth: 0,
         borderRadius: 0,
         overflow: 'visible',
@@ -92,6 +92,7 @@ export const createCalendarStyles = (isDark: boolean, subColor: string): Calenda
         backgroundColor: isDark ? '#000000' : '#FFFFFF',
         borderTopWidth: StyleSheet.hairlineWidth,
         borderTopColor: isDark ? '#202020' : '#888888',
+        width: '100%',
     },
     list: {
         flex: 1,


### PR DESCRIPTION
## Summary
- remove border wrapper on small calendar view
- keep equal side margin for full calendar view

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1300ae88326ae664959d124f15d