### PR TITLE
Reuse ConfirmModal across app

### DIFF
--- a/components/ConfirmModal.tsx
+++ b/components/ConfirmModal.tsx
@@ -1,4 +1,4 @@
-// app/features/add/components/DeadlineSettingModal/ConfirmModal.tsx
+// components/ConfirmModal.tsx
 import React, { useContext, useMemo } from 'react';
 import { Modal, View, Text, TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { useAppTheme } from '@/hooks/ThemeContext';

--- a/features/add/components/DeadlineSettingModal/index.tsx
+++ b/features/add/components/DeadlineSettingModal/index.tsx
@@ -20,7 +20,7 @@ import { createDeadlineModalStyles } from './styles';
 import { DeadlineModalHeader } from './DeadlineModalHeader';
 import { DateSelectionTab } from './DateSelectionTab';
 import { RepeatTab } from './RepeatTab';
-import { ConfirmModal } from './ConfirmModal';
+import { ConfirmModal } from '@/components/ConfirmModal';
 
 interface DeadlineSettingModalProps {
   visible: boolean;

--- a/features/settings/repeating-tasks.tsx
+++ b/features/settings/repeating-tasks.tsx
@@ -13,7 +13,7 @@ import { Ionicons } from '@expo/vector-icons';
 import type { Task } from '@/features/tasks/types';
 import type { DeadlineSettings, RepeatFrequency, CustomIntervalUnit } from '@/features/add/components/DeadlineSettingModal/types';
 import { DeadlineSettingModal } from '@/features/add/components/DeadlineSettingModal';
-import { ConfirmModal } from '@/features/add/components/DeadlineSettingModal/ConfirmModal';
+import { ConfirmModal } from '@/components/ConfirmModal';
 
 
 const STORAGE_KEY = 'TASKS';


### PR DESCRIPTION
## Summary
- create `components/ConfirmModal` for shared alert UI
- replace React Native alerts with `ConfirmModal`
- use central modal in drafts, task detail and repeating tasks
- update imports after move

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6842e75d4e3c8326ac79b29393619996