### PR TITLE
Add action menu to task detail

### DIFF
--- a/features/taskDetail/components/TaskActionModal.tsx
+++ b/features/taskDetail/components/TaskActionModal.tsx
@@ -1,0 +1,97 @@
+import React, { useContext, useMemo } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Platform, ViewStyle, TextStyle } from 'react-native';
+import Modal from 'react-native-modal';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAppTheme } from '@/hooks/ThemeContext';
+import { FontSizeContext, type FontSizeKey } from '@/context/FontSizeContext';
+import { fontSizes } from '@/constants/fontSizes';
+
+export type TaskActionModalProps = {
+  visible: boolean;
+  onClose: () => void;
+  onToggleDone: () => void;
+  onShare: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+const BACKDROP_OPACITY = 0.4;
+const ANIMATION_TIMING = 250;
+
+type Styles = {
+  modal: ViewStyle;
+  container: ViewStyle;
+  option: ViewStyle;
+  optionText: TextStyle;
+  separator: ViewStyle;
+};
+
+const createStyles = (isDark: boolean, fsKey: FontSizeKey) => {
+  return StyleSheet.create<Styles>({
+    modal: { justifyContent: 'flex-end', margin: 0 },
+    container: {
+      backgroundColor: isDark ? '#2C2C2E' : '#FFFFFF',
+      borderTopLeftRadius: 16,
+      borderTopRightRadius: 16,
+      overflow: 'hidden',
+    },
+    option: { paddingVertical: 14, paddingHorizontal: 20 },
+    optionText: {
+      fontSize: fontSizes[fsKey] + 2,
+      textAlign: 'center',
+      color: isDark ? '#E0E0E0' : '#222222',
+    },
+    separator: { height: StyleSheet.hairlineWidth, backgroundColor: isDark ? '#444' : '#DDD' },
+  });
+};
+
+export const TaskActionModal: React.FC<TaskActionModalProps> = ({
+  visible,
+  onClose,
+  onToggleDone,
+  onShare,
+  onEdit,
+  onDelete,
+}) => {
+  const { colorScheme } = useAppTheme();
+  const isDark = colorScheme === 'dark';
+  const { fontSizeKey } = useContext(FontSizeContext);
+  const styles = useMemo(() => createStyles(isDark, fontSizeKey), [isDark, fontSizeKey]);
+
+  return (
+    <Modal
+      isVisible={visible}
+      animationIn="slideInUp"
+      animationOut="slideOutDown"
+      animationInTiming={ANIMATION_TIMING}
+      animationOutTiming={ANIMATION_TIMING}
+      backdropTransitionInTiming={ANIMATION_TIMING}
+      backdropTransitionOutTiming={ANIMATION_TIMING}
+      useNativeDriver={Platform.OS === 'android'}
+      useNativeDriverForBackdrop
+      backdropOpacity={BACKDROP_OPACITY}
+      onBackdropPress={onClose}
+      onBackButtonPress={onClose}
+      style={styles.modal}
+      hideModalContentWhileAnimating
+    >
+      <SafeAreaView edges={[ 'bottom' ]} style={styles.container}>
+        <TouchableOpacity onPress={() => { onClose(); onToggleDone(); }} activeOpacity={0.7} style={styles.option}>
+          <Text style={styles.optionText}>□完了済みにする</Text>
+        </TouchableOpacity>
+        <View style={styles.separator} />
+        <TouchableOpacity onPress={() => { onClose(); onShare(); }} activeOpacity={0.7} style={styles.option}>
+          <Text style={styles.optionText}>共有</Text>
+        </TouchableOpacity>
+        <View style={styles.separator} />
+        <TouchableOpacity onPress={() => { onClose(); onEdit(); }} activeOpacity={0.7} style={styles.option}>
+          <Text style={styles.optionText}>編集</Text>
+        </TouchableOpacity>
+        <View style={styles.separator} />
+        <TouchableOpacity onPress={() => { onClose(); onDelete(); }} activeOpacity={0.7} style={styles.option}>
+          <Text style={[styles.optionText, { color: 'red' }]}>消去</Text>
+        </TouchableOpacity>
+      </SafeAreaView>
+    </Modal>
+  );
+};

--- a/features/taskDetail/screens/TaskDetailScreen.tsx
+++ b/features/taskDetail/screens/TaskDetailScreen.tsx
@@ -18,7 +18,6 @@ import {
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
-import { BlurView } from 'expo-blur';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAppTheme } from '@/hooks/ThemeContext';
@@ -29,6 +28,7 @@ import dayjs from 'dayjs'; // dayjs をインポート
 import type { DeadlineSettings } from '@/features/add/components/DeadlineSettingModal/types'; // DeadlineSettings の型をインポート
 import { getTimeText } from '@/features/tasks/utils';
 import { ConfirmModal } from '@/components/ConfirmModal';
+import { TaskActionModal } from '../components/TaskActionModal';
 
 const STORAGE_KEY = 'TASKS';
 
@@ -55,10 +55,6 @@ type TaskDetailStyles = {
   field: TextStyle;
   countdown: TextStyle;
   image: ImageStyle;
-  menuModalBlur: ViewStyle;
-  menuModalContainer: ViewStyle;
-  menuModalContent: ViewStyle;
-  menuOption: TextStyle;
   appBarMenuButton: ViewStyle;
 };
 
@@ -115,27 +111,6 @@ const createStyles = (isDark: boolean, subColor: string, fsKey: FontSizeKey) =>
       width: '100%',
       height: '100%',
       borderRadius: 8,
-    },
-    menuModalBlur: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-    menuModalContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
-    menuModalContent: {
-      backgroundColor: isDark ? '#2C2C2E' : '#FFFFFF',
-      borderRadius: 16,
-      padding: 24,
-      width: '80%',
-      maxWidth: 300,
-      alignItems: 'stretch',
-      shadowColor: '#000',
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.25,
-      shadowRadius: 3.84,
-      elevation: 5,
-    },
-    menuOption: {
-      fontSize: fontSizes[fsKey] + 2,
-      paddingVertical: 12,
-      textAlign: 'center',
-      color: isDark ? '#E0E0E0' : '#222222',
     },
     appBarMenuButton: { padding: 8, marginLeft: 8 },
   });
@@ -329,30 +304,14 @@ const createStyles = (isDark: boolean, subColor: string, fsKey: FontSizeKey) =>
           </TouchableOpacity>
         </Modal>
       </ScrollView>
-      <Modal transparent visible={isMenuVisible} animationType="fade" onRequestClose={() => setIsMenuVisible(false)}>
-        <BlurView intensity={isDark ? 20 : 70} tint={isDark ? 'dark' : 'light'} style={styles.menuModalBlur}>
-          <TouchableOpacity style={StyleSheet.absoluteFill} onPress={() => setIsMenuVisible(false)} />
-          <View style={styles.menuModalContainer}>
-            <View style={styles.menuModalContent}>
-              <TouchableOpacity onPress={() => { setIsMenuVisible(false); handleToggleDone(); }} activeOpacity={0.7}>
-                <Text style={styles.menuOption}>□完了済みにする</Text>
-              </TouchableOpacity>
-              <View style={{height: StyleSheet.hairlineWidth, backgroundColor: isDark ? '#444' : '#DDD'}} />
-              <TouchableOpacity onPress={() => { setIsMenuVisible(false); handleShare(); }} activeOpacity={0.7}>
-                <Text style={styles.menuOption}>共有</Text>
-              </TouchableOpacity>
-              <View style={{height: StyleSheet.hairlineWidth, backgroundColor: isDark ? '#444' : '#DDD'}} />
-              <TouchableOpacity onPress={() => { setIsMenuVisible(false); handleEdit(); }} activeOpacity={0.7}>
-                <Text style={styles.menuOption}>編集</Text>
-              </TouchableOpacity>
-              <View style={{height: StyleSheet.hairlineWidth, backgroundColor: isDark ? '#444' : '#DDD'}} />
-              <TouchableOpacity onPress={() => { setIsMenuVisible(false); handleDelete(); }} activeOpacity={0.7}>
-                <Text style={[styles.menuOption, {color: 'red'}]}>消去</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        </BlurView>
-      </Modal>
+      <TaskActionModal
+        visible={isMenuVisible}
+        onClose={() => setIsMenuVisible(false)}
+        onToggleDone={handleToggleDone}
+        onShare={handleShare}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+      />
       
       <ConfirmModal
         visible={isDeleteConfirmVisible}


### PR DESCRIPTION
## Summary
- add menu button to open task actions
- remove bottom action bar
- show complete/share/edit/delete options in modal

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842eeabc2788326840a11226a8bd785