### PR TITLE
Fix missing Task fields in detail screen

### DIFF
--- a/features/taskDetail/screens/TaskDetailScreen.tsx
+++ b/features/taskDetail/screens/TaskDetailScreen.tsx
@@ -26,28 +26,18 @@ import { FontSizeContext, type FontSizeKey } from '@/context/FontSizeContext';
 import { fontSizes } from '@/constants/fontSizes';
 import dayjs from 'dayjs'; // dayjs をインポート
 import type { DeadlineSettings } from '@/features/add/components/DeadlineSettingModal/types'; // DeadlineSettings の型をインポート
+import type { Task } from '@/features/add/types';
 import { getTimeText } from '@/features/tasks/utils';
 import { ConfirmModal } from '@/components/ConfirmModal';
 
 const STORAGE_KEY = 'TASKS';
-
-type Task = {
-  id: string;
-  title: string;
-  memo: string;
-  deadline?: string; // deadline はオプショナルに変更
-  imageUris: string[];
-  notifyEnabled: boolean;
-  customUnit: 'minutes' | 'hours' | 'days';
-  customAmount: number;
-  deadlineDetails?: DeadlineSettings; // deadlineDetails プロパティを追加
-};
 
 type TaskDetailStyles = {
   container: ViewStyle;
   appBar: ViewStyle;
   appBarTitle: TextStyle;
   backButton: ViewStyle;
+  appBarActionPlaceholder: ViewStyle;
   title: TextStyle;
   label: TextStyle;
   memo: TextStyle;


### PR DESCRIPTION
## Summary
- use the shared `Task` type in `TaskDetailScreen`
- include `appBarActionPlaceholder` style in TaskDetail styles

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'dayjs/plugin/timezone' et al.)*

------
https://chatgpt.com/codex/tasks/task_e_6842f3b3d7f48326ad37d2368b167931