### PR TITLE
Fix modal flicker by delaying state updates

### DIFF
--- a/features/add/components/DeadlineSettingModal/index.tsx
+++ b/features/add/components/DeadlineSettingModal/index.tsx
@@ -1,6 +1,6 @@
 // app/features/add/components/DeadlineSettingModal/index.tsx
 import React, { useState, useEffect, useCallback, useContext, useMemo } from 'react';
-import { View, TouchableOpacity, Text, useWindowDimensions, Platform, InteractionManager } from 'react-native';
+import { View, TouchableOpacity, Text, useWindowDimensions, Platform } from 'react-native';
 import Modal from 'react-native-modal';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { TabView, SceneRendererProps, TabBarProps } from 'react-native-tab-view';
@@ -72,39 +72,35 @@ export const DeadlineSettingModal: React.FC<DeadlineSettingModalProps> = ({
 
 
   useEffect(() => {
-    if (visible) {
-      InteractionManager.runAfterInteractions(() => {
-        const defaults = getDefaultInitialSettings();
-        let effectiveInitialSettings = { ...defaults };
+    const defaults = getDefaultInitialSettings();
+    let effectiveInitialSettings = { ...defaults };
 
-        if (initialSettings) {
-           effectiveInitialSettings = {
-            ...defaults,
-            taskDeadlineDate: initialSettings.taskDeadlineDate,
-            taskDeadlineTime: initialSettings.taskDeadlineTime,
-            isTaskDeadlineTimeEnabled: initialSettings.isTaskDeadlineTimeEnabled,
-            repeatFrequency: initialSettings.repeatFrequency,
-            repeatStartDate: initialSettings.repeatStartDate || defaults.repeatStartDate,
-            repeatDaysOfWeek: initialSettings.repeatDaysOfWeek,
-            repeatEnds: initialSettings.repeatEnds,
-            isExcludeHolidays: initialSettings.isExcludeHolidays ?? defaults.isExcludeHolidays,
-            customIntervalValue: initialSettings.customIntervalValue || defaults.customIntervalValue,
-            customIntervalUnit: initialSettings.customIntervalUnit || defaults.customIntervalUnit,
-          };
-        }
-        setSettings(effectiveInitialSettings);
-
-        if (effectiveInitialSettings.repeatFrequency) {
-            setActiveTabIndex(1);
-        } else {
-            setActiveTabIndex(0);
-        }
-      });
-    } else {
-        setValidationErrorModalVisible(false);
-        setValidationErrorMessage('');
+    if (initialSettings) {
+      effectiveInitialSettings = {
+        ...defaults,
+        taskDeadlineDate: initialSettings.taskDeadlineDate,
+        taskDeadlineTime: initialSettings.taskDeadlineTime,
+        isTaskDeadlineTimeEnabled: initialSettings.isTaskDeadlineTimeEnabled,
+        repeatFrequency: initialSettings.repeatFrequency,
+        repeatStartDate: initialSettings.repeatStartDate || defaults.repeatStartDate,
+        repeatDaysOfWeek: initialSettings.repeatDaysOfWeek,
+        repeatEnds: initialSettings.repeatEnds,
+        isExcludeHolidays: initialSettings.isExcludeHolidays ?? defaults.isExcludeHolidays,
+        customIntervalValue: initialSettings.customIntervalValue || defaults.customIntervalValue,
+        customIntervalUnit: initialSettings.customIntervalUnit || defaults.customIntervalUnit,
+      };
     }
-  }, [visible, initialSettings]);
+
+    setSettings(effectiveInitialSettings);
+    setActiveTabIndex(effectiveInitialSettings.repeatFrequency ? 1 : 0);
+  }, [initialSettings]);
+
+  useEffect(() => {
+    if (!visible) {
+      setValidationErrorModalVisible(false);
+      setValidationErrorMessage('');
+    }
+  }, [visible]);
 
   const updateSettingsCallback = useCallback(
     <K extends keyof DeadlineSettings>(key: K, value: DeadlineSettings[K]) => {

--- a/features/add/index.tsx
+++ b/features/add/index.tsx
@@ -47,6 +47,8 @@ const PHOTO_LIST_HORIZONTAL_PADDING = 8 * 2;
 const MIN_IMAGE_SIZE = 120;
 const IMAGE_MARGIN = 8;
 const DESTRUCTIVE_ACTION_COLOR = '#FF3B30';
+// モーダルの閉じるアニメーション時間（ミリ秒）
+const MODAL_ANIMATION_DELAY = 300;
 
 const formatDateForDisplayInternal = (dateString: string | undefined, t: Function, i18nLanguage: string): string => {
     if (!dateString) return t('add_task.unselected_date_placeholder', '未選択');
@@ -318,17 +320,21 @@ export default function AddTaskScreen() {
 
 
   const handleSetNoNotificationInModal = () => {
-    setNotificationActive(false);
-    setCustomAmount(initialFormState.customAmount);
-    setCustomUnit(initialFormState.customUnit);
     setShowWheelModal(false);
+    setTimeout(() => {
+      setNotificationActive(false);
+      setCustomAmount(initialFormState.customAmount);
+      setCustomUnit(initialFormState.customUnit);
+    }, MODAL_ANIMATION_DELAY);
   };
 
   const handleConfirmNotificationInModal = (amount: number, unit: NotificationUnit) => {
-    setNotificationActive(true);
-    setCustomAmount(amount);
-    setCustomUnit(unit);
     setShowWheelModal(false);
+    setTimeout(() => {
+      setNotificationActive(true);
+      setCustomAmount(amount);
+      setCustomUnit(unit);
+    }, MODAL_ANIMATION_DELAY);
   };
 
   const renderPhotoItem = ({ item, index }: { item: string; index: number }) => {
@@ -524,8 +530,10 @@ export default function AddTaskScreen() {
           visible={showFolderModal}
           onClose={() => setShowFolderModal(false)}
           onSubmit={(name) => {
-            setFolder(name);
             setShowFolderModal(false);
+            setTimeout(() => {
+              setFolder(name);
+            }, MODAL_ANIMATION_DELAY);
           }}
           folders={folders}
         />
@@ -542,18 +550,16 @@ export default function AddTaskScreen() {
           onClose={() => setShowDeadlineModal(false)}
           onSave={(newSettings) => {
             let processedSettings = newSettings;
-            // newSettings (つまり processedSettings) が null または undefined でないことを確認してから
-            // repeatFrequency プロパティにアクセスします。
             if (processedSettings && processedSettings.repeatFrequency) {
                 const {
-                    // taskStartTime, // 廃止
-                    // isTaskStartTimeEnabled, // 廃止
                     ...restOfDetails
                 } = processedSettings;
                 processedSettings = restOfDetails;
             }
-            setCurrentDeadlineSettings(processedSettings);
             setShowDeadlineModal(false);
+            setTimeout(() => {
+              setCurrentDeadlineSettings(processedSettings);
+            }, MODAL_ANIMATION_DELAY);
           }}
           initialSettings={currentDeadlineSettings}
         />

--- a/features/add_edit/screens/EditTaskScreen.tsx
+++ b/features/add_edit/screens/EditTaskScreen.tsx
@@ -29,6 +29,8 @@ const PHOTO_LIST_HORIZONTAL_PADDING = 8 * 2;
 const MIN_IMAGE_SIZE = 120;
 const IMAGE_MARGIN = 8;
 const DESTRUCTIVE_ACTION_COLOR = '#FF3B30';
+// モーダルの閉じるアニメーション時間（ミリ秒）
+const MODAL_ANIMATION_DELAY = 300;
 
 export default function EditTaskScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -153,17 +155,21 @@ export default function EditTaskScreen() {
   });
 
   const handleSetNoNotificationInModal = () => {
-    setNotificationActive(false);
-    setCustomAmount(1);
-    setCustomUnit('hours');
     setShowWheelModal(false);
+    setTimeout(() => {
+      setNotificationActive(false);
+      setCustomAmount(1);
+      setCustomUnit('hours');
+    }, MODAL_ANIMATION_DELAY);
   };
 
   const handleConfirmNotificationInModal = (amount:number, unit:'minutes'|'hours'|'days') => {
-    setNotificationActive(true);
-    setCustomAmount(amount);
-    setCustomUnit(unit);
     setShowWheelModal(false);
+    setTimeout(() => {
+      setNotificationActive(true);
+      setCustomAmount(amount);
+      setCustomUnit(unit);
+    }, MODAL_ANIMATION_DELAY);
   };
 
   const renderPhotoItem = ({ item, index }: { item: string; index: number }) => (
@@ -329,7 +335,12 @@ export default function EditTaskScreen() {
       <FolderSelectorModal
         visible={showFolderModal}
         onClose={() => setShowFolderModal(false)}
-        onSubmit={(name) => { setFolder(name); setShowFolderModal(false); }}
+        onSubmit={(name) => {
+          setShowFolderModal(false);
+          setTimeout(() => {
+            setFolder(name);
+          }, MODAL_ANIMATION_DELAY);
+        }}
         folders={folders}
       />
       <WheelPickerModal
@@ -343,7 +354,12 @@ export default function EditTaskScreen() {
       <DeadlineSettingModal
         visible={showDeadlineModal}
         onClose={() => setShowDeadlineModal(false)}
-        onSave={(newSettings) => { setCurrentDeadlineSettings(newSettings); setShowDeadlineModal(false); }}
+        onSave={(newSettings) => {
+          setShowDeadlineModal(false);
+          setTimeout(() => {
+            setCurrentDeadlineSettings(newSettings);
+          }, MODAL_ANIMATION_DELAY);
+        }}
         initialSettings={currentDeadlineSettings}
       />
       <Modal visible={!!previewUri} transparent animationType="fade">


### PR DESCRIPTION
## Summary
- improve AddTaskScreen modal handling by updating state after closing animation
- improve EditTaskScreen modal handling similarly

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68431478915c8326b4b4fe4330356d02