### PR TITLE
Implement Google Calendar API sync with background service

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can start developing by editing the files inside the **app** directory. This
 
 ### Google Calendar integration
 
-To display events from Google Calendar, set the environment variable `EXPO_PUBLIC_GOOGLE_CALENDAR_ICS_URL` to the public iCalendar URL of the calendar. When `Googleカレンダー連携` is enabled in the settings screen, events for the selected day will appear above the task list.
+Events are now synced using the Google Calendar API. Set `EXPO_PUBLIC_GOOGLE_CLIENT_ID` to your OAuth client ID. The app performs background synchronization using a headless task and caches events in a native SQLite database. Only changes since the last sync are fetched by utilizing the API sync token mechanism. When `Googleカレンダー連携` is enabled in the settings screen, events for the selected day will appear above the task list.
 
 ## Get a fresh project
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,5 +30,6 @@
         <data android:scheme="myapp"/>
       </intent-filter>
     </activity>
+    <service android:name="com.fukuroulu.app.calendar.GoogleSyncService" android:exported="false" />
   </application>
 </manifest>

--- a/android/app/src/main/java/com/fukuroulu/app/MainApplication.kt
+++ b/android/app/src/main/java/com/fukuroulu/app/MainApplication.kt
@@ -16,6 +16,7 @@ import com.facebook.soloader.SoLoader
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
 import com.fukuroulu.app.db.TasksDatabasePackage
+import com.fukuroulu.app.calendar.EventsDatabasePackage
 
 class MainApplication : Application(), ReactApplication {
 
@@ -26,6 +27,7 @@ class MainApplication : Application(), ReactApplication {
             val packages = PackageList(this).packages
             // Packages that cannot be autolinked yet can be added manually here, for example:
             packages.add(TasksDatabasePackage())
+            packages.add(EventsDatabasePackage())
             return packages
           }
 

--- a/android/app/src/main/java/com/fukuroulu/app/calendar/EventsDatabaseHelper.kt
+++ b/android/app/src/main/java/com/fukuroulu/app/calendar/EventsDatabaseHelper.kt
@@ -1,0 +1,23 @@
+package com.fukuroulu.app.calendar
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+
+private const val DATABASE_NAME = "events.db"
+private const val DATABASE_VERSION = 1
+
+class EventsDatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS events (" +
+                    "id TEXT PRIMARY KEY NOT NULL, " +
+                    "json TEXT NOT NULL" +
+            ")"
+        )
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        // handle migrations
+    }
+}

--- a/android/app/src/main/java/com/fukuroulu/app/calendar/EventsDatabaseModule.kt
+++ b/android/app/src/main/java/com/fukuroulu/app/calendar/EventsDatabaseModule.kt
@@ -1,0 +1,57 @@
+package com.fukuroulu.app.calendar
+
+import com.facebook.react.bridge.*
+import org.json.JSONObject
+
+class EventsDatabaseModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+    private val helper = EventsDatabaseHelper(reactContext)
+
+    override fun getName(): String = "EventsDatabase"
+
+    @ReactMethod
+    fun initialize(promise: Promise) {
+        helper.writableDatabase
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun saveEvent(event: ReadableMap, promise: Promise) {
+        val db = helper.writableDatabase
+        val json = JSONObject(event.toHashMap()).toString()
+        val id = event.getString("id") ?: run {
+            promise.reject("no_id", "Event id is required")
+            return
+        }
+        val stmt = db.compileStatement("INSERT OR REPLACE INTO events (id, json) VALUES (?, ?)")
+        stmt.bindString(1, id)
+        stmt.bindString(2, json)
+        stmt.execute()
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun getAllEvents(promise: Promise) {
+        val db = helper.readableDatabase
+        val cursor = db.rawQuery("SELECT json FROM events", null)
+        val array = Arguments.createArray()
+        while (cursor.moveToNext()) {
+            array.pushString(cursor.getString(0))
+        }
+        cursor.close()
+        promise.resolve(array)
+    }
+
+    @ReactMethod
+    fun deleteEvent(id: String, promise: Promise) {
+        val db = helper.writableDatabase
+        db.delete("events", "id=?", arrayOf(id))
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun clearEvents(promise: Promise) {
+        val db = helper.writableDatabase
+        db.delete("events", null, null)
+        promise.resolve(null)
+    }
+}

--- a/android/app/src/main/java/com/fukuroulu/app/calendar/EventsDatabasePackage.kt
+++ b/android/app/src/main/java/com/fukuroulu/app/calendar/EventsDatabasePackage.kt
@@ -1,0 +1,14 @@
+package com.fukuroulu.app.calendar
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class EventsDatabasePackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return listOf(EventsDatabaseModule(reactContext))
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> = emptyList()
+}

--- a/android/app/src/main/java/com/fukuroulu/app/calendar/GoogleSyncService.kt
+++ b/android/app/src/main/java/com/fukuroulu/app/calendar/GoogleSyncService.kt
@@ -1,0 +1,17 @@
+package com.fukuroulu.app.calendar
+
+import android.content.Intent
+import com.facebook.react.HeadlessJsTaskService
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.jstasks.HeadlessJsTaskConfig
+
+class GoogleSyncService : HeadlessJsTaskService() {
+    override fun getTaskConfig(intent: Intent?): HeadlessJsTaskConfig? {
+        return HeadlessJsTaskConfig(
+            "GoogleCalendarSync",
+            intent?.extras ?: Arguments.createMap(),
+            0,
+            true
+        )
+    }
+}

--- a/background/GoogleSyncTask.ts
+++ b/background/GoogleSyncTask.ts
@@ -1,0 +1,21 @@
+import EventDatabase from '../lib/EventDatabase'
+import * as SecureStore from 'expo-secure-store'
+import { fetchEvents } from '../lib/GoogleCalendarApi'
+
+export default async function GoogleSyncTask() {
+  await EventDatabase.initialize()
+  const token = await SecureStore.getItemAsync('google_calendar_sync_token')
+  try {
+    const result = await fetchEvents(token || undefined)
+    if (result.nextSyncToken) {
+      await SecureStore.setItemAsync('google_calendar_sync_token', result.nextSyncToken)
+    }
+    if (Array.isArray(result.items)) {
+      for (const item of result.items) {
+        await EventDatabase.saveEvent({ id: item.id, ...item })
+      }
+    }
+  } catch (e) {
+    console.warn('Sync failed', e)
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,5 @@
-import 'expo-router/entry';
+import 'expo-router/entry'
+import { AppRegistry } from 'react-native'
+import GoogleSyncTask from './background/GoogleSyncTask'
+
+AppRegistry.registerHeadlessTask('GoogleCalendarSync', () => GoogleSyncTask)

--- a/lib/EventDatabase.ts
+++ b/lib/EventDatabase.ts
@@ -1,0 +1,18 @@
+import { NativeModules } from 'react-native'
+
+export type EventRecord = {
+  id: string
+  [key: string]: any
+}
+
+interface EventsDatabaseModule {
+  initialize(): Promise<void>
+  saveEvent(event: EventRecord): Promise<void>
+  getAllEvents(): Promise<string[]>
+  deleteEvent(id: string): Promise<void>
+  clearEvents(): Promise<void>
+}
+
+const { EventsDatabase } = NativeModules
+
+export default EventsDatabase as EventsDatabaseModule

--- a/lib/GoogleCalendarApi.ts
+++ b/lib/GoogleCalendarApi.ts
@@ -1,0 +1,112 @@
+import * as AuthSession from 'expo-auth-session'
+import * as SecureStore from 'expo-secure-store'
+
+const discovery = {
+  authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+  tokenEndpoint: 'https://oauth2.googleapis.com/token',
+  revocationEndpoint: 'https://oauth2.googleapis.com/revoke',
+}
+
+const SCOPES = ['https://www.googleapis.com/auth/calendar']
+const ACCESS_TOKEN_KEY = 'google_access_token'
+const REFRESH_TOKEN_KEY = 'google_refresh_token'
+
+export type GoogleEventInput = {
+  id?: string
+  summary: string
+  start: { dateTime: string }
+  end: { dateTime: string }
+}
+
+export async function authenticateAsync() {
+  const clientId = process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID
+  if (!clientId) throw new Error('No client id')
+  const redirectUri = AuthSession.makeRedirectUri({ useProxy: true })
+  const result = await AuthSession.startAsync({
+    authUrl:
+      discovery.authorizationEndpoint +
+      `?client_id=${clientId}` +
+      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&response_type=code` +
+      `&scope=${encodeURIComponent(SCOPES.join(' '))}`,
+  })
+  if (result.type !== 'success') return
+  const tokenRes = await AuthSession.exchangeCodeAsync(
+    {
+      clientId,
+      code: result.params.code,
+      redirectUri,
+      extraParams: { code_verifier: result.params.code_verifier },
+    },
+    discovery
+  )
+  if (tokenRes.accessToken) await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, tokenRes.accessToken)
+  if (tokenRes.refreshToken) await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, tokenRes.refreshToken)
+}
+
+async function getAccessToken(): Promise<string | null> {
+  let token = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY)
+  if (token) return token
+  const refresh = await SecureStore.getItemAsync(REFRESH_TOKEN_KEY)
+  if (!refresh) return null
+  const clientId = process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID
+  if (!clientId) return null
+  const res = await fetch(discovery.tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `client_id=${clientId}&grant_type=refresh_token&refresh_token=${refresh}`,
+  })
+  const json = await res.json()
+  token = json.access_token
+  if (token) await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, token)
+  return token
+}
+
+export async function fetchEvents(syncToken?: string) {
+  const token = await getAccessToken()
+  if (!token) throw new Error('No access token')
+  const params = new URLSearchParams()
+  params.append('singleEvents', 'true')
+  if (syncToken) {
+    params.append('syncToken', syncToken)
+  } else {
+    params.append('timeMin', new Date(0).toISOString())
+  }
+  const res = await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events?${params.toString()}`,
+    { headers: { Authorization: `Bearer ${token}` } })
+  if (!res.ok) throw new Error('Failed to fetch events')
+  return res.json()
+}
+
+export async function insertEvent(event: GoogleEventInput) {
+  const token = await getAccessToken()
+  if (!token) throw new Error('No access token')
+  const res = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(event),
+  })
+  if (!res.ok) throw new Error('Failed to create event')
+  return res.json()
+}
+
+export async function updateEvent(eventId: string, event: GoogleEventInput) {
+  const token = await getAccessToken()
+  if (!token) throw new Error('No access token')
+  const res = await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events/${eventId}`, {
+    method: 'PUT',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(event),
+  })
+  if (!res.ok) throw new Error('Failed to update event')
+  return res.json()
+}
+
+export async function deleteEvent(eventId: string) {
+  const token = await getAccessToken()
+  if (!token) throw new Error('No access token')
+  await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events/${eventId}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}


### PR DESCRIPTION
## Summary
- integrate Google Calendar API with OAuth handling
- add headless task to sync events using API
- cache calendar events in native SQLite database
- register new background service and headless task
- document Google Calendar API usage

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6843af76b76c83268846e7d08455641a