### PR TITLE
Fix DB load failure when native modules missing

### DIFF
--- a/lib/EventDatabase.ts
+++ b/lib/EventDatabase.ts
@@ -1,4 +1,5 @@
 import { NativeModules } from 'react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 
 export type EventRecord = {
   id: string
@@ -15,4 +16,49 @@ interface EventsDatabaseModule {
 
 const { EventsDatabase } = NativeModules
 
-export default EventsDatabase as EventsDatabaseModule
+const EVENTS_KEY = 'EVENTS'
+
+async function loadAll(): Promise<string[]> {
+  const raw = await AsyncStorage.getItem(EVENTS_KEY)
+  if (!raw) return []
+  try {
+    const arr = JSON.parse(raw) as EventRecord[]
+    return arr.map(e => JSON.stringify(e))
+  } catch {
+    return []
+  }
+}
+
+async function save(event: EventRecord) {
+  const raw = await AsyncStorage.getItem(EVENTS_KEY)
+  const events: EventRecord[] = raw ? JSON.parse(raw) : []
+  const index = events.findIndex(e => e.id === event.id)
+  if (index !== -1) {
+    events[index] = event
+  } else {
+    events.push(event)
+  }
+  await AsyncStorage.setItem(EVENTS_KEY, JSON.stringify(events))
+}
+
+async function remove(id: string) {
+  const raw = await AsyncStorage.getItem(EVENTS_KEY)
+  if (!raw) return
+  const events: EventRecord[] = JSON.parse(raw)
+  const filtered = events.filter(e => e.id !== id)
+  await AsyncStorage.setItem(EVENTS_KEY, JSON.stringify(filtered))
+}
+
+async function clearStorage() {
+  await AsyncStorage.removeItem(EVENTS_KEY)
+}
+
+const fallback: EventsDatabaseModule = {
+  initialize: async () => {},
+  saveEvent: save,
+  getAllEvents: loadAll,
+  deleteEvent: remove,
+  clearEvents: clearStorage,
+}
+
+export default (EventsDatabase ?? fallback) as EventsDatabaseModule

--- a/lib/TaskDatabase.ts
+++ b/lib/TaskDatabase.ts
@@ -1,4 +1,6 @@
 import { NativeModules } from 'react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { STORAGE_KEY as TASKS_KEY } from '@/features/tasks/constants'
 
 export type TaskRecord = {
   id: string
@@ -14,4 +16,42 @@ interface TasksDatabaseModule {
 
 const { TasksDatabase } = NativeModules
 
-export default TasksDatabase as TasksDatabaseModule
+async function loadAllFromStorage(): Promise<string[]> {
+  const raw = await AsyncStorage.getItem(TASKS_KEY)
+  if (!raw) return []
+  try {
+    const arr = JSON.parse(raw) as TaskRecord[]
+    return arr.map(t => JSON.stringify(t))
+  } catch {
+    return []
+  }
+}
+
+async function saveToStorage(task: TaskRecord) {
+  const raw = await AsyncStorage.getItem(TASKS_KEY)
+  const tasks: TaskRecord[] = raw ? JSON.parse(raw) : []
+  const index = tasks.findIndex(t => t.id === task.id)
+  if (index !== -1) {
+    tasks[index] = task
+  } else {
+    tasks.push(task)
+  }
+  await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks))
+}
+
+async function deleteFromStorage(id: string) {
+  const raw = await AsyncStorage.getItem(TASKS_KEY)
+  if (!raw) return
+  const tasks: TaskRecord[] = JSON.parse(raw)
+  const updated = tasks.filter(t => t.id !== id)
+  await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(updated))
+}
+
+const fallback: TasksDatabaseModule = {
+  initialize: async () => {},
+  saveTask: saveToStorage,
+  getAllTasks: loadAllFromStorage,
+  deleteTask: deleteFromStorage,
+}
+
+export default (TasksDatabase ?? fallback) as TasksDatabaseModule


### PR DESCRIPTION
## Summary
- add AsyncStorage fallback for TasksDatabase and EventsDatabase

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843b92be0e08326a1ef7486abc9969b