### PR TITLE
Add iOS EventsDatabase and update DB usage

### DIFF
--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -3,6 +3,7 @@ import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { View, FlatList, Text, ActivityIndicator, Pressable, TouchableOpacity, Platform, useWindowDimensions } from 'react-native';
 import { useFocusEffect, useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import TasksDatabase from '@/lib/TaskDatabase';
 import { Gesture, GestureDetector, Directions } from 'react-native-gesture-handler';
 import { useSharedValue, withTiming, runOnJS } from 'react-native-reanimated';
 import PagerView, { type PagerViewOnPageSelectedEvent } from 'react-native-pager-view';
@@ -71,12 +72,13 @@ export default function CalendarPage() {
       const loadData = async () => {
         const savedId = await AsyncStorage.getItem(CALENDAR_BG_KEY);
         const selectedImage = BACKGROUND_IMAGES.find(img => img.id === savedId);
-        
+
         setBackgroundImage(selectedImage ? selectedImage.source : null);
 
         try {
-          const rawTasks = await AsyncStorage.getItem(TASKS_KEY);
-          setTasks(rawTasks ? JSON.parse(rawTasks) : []);
+          await TasksDatabase.initialize();
+          const rawTasks = await TasksDatabase.getAllTasks();
+          setTasks(rawTasks.map(t => JSON.parse(t)));
         } catch {
           setTasks([]);
         }

--- a/features/tasks/hooks/useTasksScreenLogic.ts
+++ b/features/tasks/hooks/useTasksScreenLogic.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Alert, Dimensions, Platform, ScrollView } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import TasksDatabase from '@/lib/TaskDatabase';
 import dayjs from 'dayjs';
 import { useFocusEffect, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -107,11 +108,12 @@ export const useTasksScreenLogic = () => {
           setLoading(true);
         }
         try {
-          const [rawTasksData, rawOrderData] = await Promise.all([
-            AsyncStorage.getItem(STORAGE_KEY),
+          await TasksDatabase.initialize();
+          const [taskRows, rawOrderData] = await Promise.all([
+            TasksDatabase.getAllTasks(),
             AsyncStorage.getItem(FOLDER_ORDER_KEY),
           ]);
-          setTasks(rawTasksData ? JSON.parse(rawTasksData) : []);
+          setTasks(taskRows.map(t => JSON.parse(t)));
           setFolderOrder(rawOrderData ? JSON.parse(rawOrderData) : []);
         } catch (e) {
           console.error('Failed to load data from storage on focus:', e);

--- a/ios/EventsDatabaseModule.h
+++ b/ios/EventsDatabaseModule.h
@@ -1,0 +1,5 @@
+#import <React/RCTBridgeModule.h>
+#import <sqlite3.h>
+
+@interface EventsDatabaseModule : NSObject <RCTBridgeModule>
+@end

--- a/ios/EventsDatabaseModule.m
+++ b/ios/EventsDatabaseModule.m
@@ -1,0 +1,114 @@
+#import "EventsDatabaseModule.h"
+
+@implementation EventsDatabaseModule
+{
+    sqlite3 *_db;
+}
+
+RCT_EXPORT_MODULE(EventsDatabase);
+
+RCT_EXPORT_METHOD(initialize:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSString *docs = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)[0];
+    NSString *path = [docs stringByAppendingPathComponent:@"events.db"];
+    if (sqlite3_open([path UTF8String], &_db) == SQLITE_OK) {
+        const char *sql = "CREATE TABLE IF NOT EXISTS events (id TEXT PRIMARY KEY NOT NULL, json TEXT NOT NULL);";
+        char *err;
+        if (sqlite3_exec(_db, sql, NULL, NULL, &err) != SQLITE_OK) {
+            reject(@"init_error", [NSString stringWithUTF8String:err], nil);
+            sqlite3_close(_db);
+            return;
+        }
+        resolve(nil);
+    } else {
+        reject(@"init_error", @"Failed to open DB", nil);
+    }
+}
+
+RCT_EXPORT_METHOD(saveEvent:(NSDictionary *)event
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSString *eventId = event[@"id"];
+    if (!eventId) {
+        reject(@"no_id", @"Event id is required", nil);
+        return;
+    }
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:event options:0 error:&error];
+    if (error) {
+        reject(@"json_error", error.localizedDescription, nil);
+        return;
+    }
+    NSString *json = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+
+    const char *sql = "INSERT OR REPLACE INTO events (id, json) VALUES (?, ?);";
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(_db, sql, -1, &stmt, NULL) == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, [eventId UTF8String], -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 2, [json UTF8String], -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(stmt) != SQLITE_DONE) {
+            reject(@"db_error", @"Failed to save event", nil);
+        } else {
+            resolve(nil);
+        }
+        sqlite3_finalize(stmt);
+    } else {
+        reject(@"db_error", @"Failed to prepare statement", nil);
+    }
+}
+
+RCT_EXPORT_METHOD(getAllEvents:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    const char *sql = "SELECT json FROM events;";
+    sqlite3_stmt *stmt;
+    NSMutableArray *result = [NSMutableArray array];
+    if (sqlite3_prepare_v2(_db, sql, -1, &stmt, NULL) == SQLITE_OK) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            const unsigned char *text = sqlite3_column_text(stmt, 0);
+            if (text) {
+                NSString *json = [NSString stringWithUTF8String:(const char *)text];
+                [result addObject:json];
+            }
+        }
+        sqlite3_finalize(stmt);
+        resolve(result);
+    } else {
+        reject(@"db_error", @"Failed to query", nil);
+    }
+}
+
+RCT_EXPORT_METHOD(deleteEvent:(NSString *)eventId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    const char *sql = "DELETE FROM events WHERE id = ?";
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(_db, sql, -1, &stmt, NULL) == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, [eventId UTF8String], -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(stmt) != SQLITE_DONE) {
+            reject(@"db_error", @"Failed to delete", nil);
+        } else {
+            resolve(nil);
+        }
+        sqlite3_finalize(stmt);
+    } else {
+        reject(@"db_error", @"Failed to prepare delete", nil);
+    }
+}
+
+RCT_EXPORT_METHOD(clearEvents:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    const char *sql = "DELETE FROM events";
+    char *err;
+    if (sqlite3_exec(_db, sql, NULL, NULL, &err) != SQLITE_OK) {
+        reject(@"db_error", [NSString stringWithUTF8String:err], nil);
+    } else {
+        resolve(nil);
+    }
+}
+
+@end


### PR DESCRIPTION
## Summary
- implement EventsDatabase native module for iOS
- use TasksDatabase to load tasks in Calendar screen
- initialize TasksDatabase when loading tasks screen logic

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843bc8254fc8326844ef45a8cd65527