### PR TITLE
Implement DB migration logic for Android

### DIFF
--- a/android/app/src/main/java/com/fukuroulu/app/calendar/EventsDatabaseHelper.kt
+++ b/android/app/src/main/java/com/fukuroulu/app/calendar/EventsDatabaseHelper.kt
@@ -5,7 +5,18 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 
 private const val DATABASE_NAME = "events.db"
-private const val DATABASE_VERSION = 1
+
+// マイグレーションを追加する配列。旧バージョンから順に処理を記述します
+private val MIGRATIONS: Array<(SQLiteDatabase) -> Unit> = arrayOf(
+    // 1 -> 2 のマイグレーション例
+    { db ->
+        // 例: カラム追加やテーブル変更など
+        // db.execSQL("ALTER TABLE events ADD COLUMN example TEXT")
+    }
+)
+
+// バージョンはマイグレーション数 + 1 で自動的に更新されるようにする
+private val DATABASE_VERSION = MIGRATIONS.size + 1
 
 class EventsDatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
     override fun onCreate(db: SQLiteDatabase) {
@@ -15,9 +26,17 @@ class EventsDatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABAS
                     "json TEXT NOT NULL" +
             ")"
         )
+
+        // 新規インストール時も最新スキーマとなるようマイグレーションを適用
+        for (migration in MIGRATIONS) {
+            migration(db)
+        }
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
-        // handle migrations
+        // バージョンを順番に上げながらマイグレーションを実行
+        for (version in oldVersion until newVersion) {
+            MIGRATIONS.getOrNull(version - 1)?.invoke(db)
+        }
     }
 }

--- a/android/app/src/main/java/com/fukuroulu/app/db/TasksDatabaseHelper.kt
+++ b/android/app/src/main/java/com/fukuroulu/app/db/TasksDatabaseHelper.kt
@@ -5,7 +5,19 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 
 private const val DATABASE_NAME = "tasks.db"
-private const val DATABASE_VERSION = 1
+
+// 各バージョンアップ用のマイグレーション関数を順番に追加していきます
+private val MIGRATIONS: Array<(SQLiteDatabase) -> Unit> = arrayOf(
+    // 1 -> 2 のマイグレーション例
+    { db ->
+        // 例: 新しいカラム追加など
+        // db.execSQL("ALTER TABLE tasks ADD COLUMN example TEXT")
+    }
+)
+
+// データベースバージョンはマイグレーション数 + 1 とすることで、
+// 新しいマイグレーションを追加するだけで自動的にバージョンが上がります
+private val DATABASE_VERSION = MIGRATIONS.size + 1
 
 class TasksDatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
     override fun onCreate(db: SQLiteDatabase) {
@@ -15,9 +27,17 @@ class TasksDatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE
                 "json TEXT NOT NULL" +
             ")"
         )
+
+        // 新規作成時にも最新スキーマとなるようマイグレーションをすべて適用
+        for (migration in MIGRATIONS) {
+            migration(db)
+        }
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
-        // バージョンアップ時のマイグレーション処理をここに追加します
+        // oldVersion から newVersion まで順番にマイグレーションを適用
+        for (version in oldVersion until newVersion) {
+            MIGRATIONS.getOrNull(version - 1)?.invoke(db)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add migration array and auto versioning for Android's SQLite helpers
- apply migrations on DB create and upgrade

## Testing
- `./android/gradlew assembleDebug` *(fails: Directory does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_6843bfd325b8832684e211ff9285e3a7