### PR TITLE
Remove AsyncStorage dependency for tasks

### DIFF
--- a/features/add/hooks/useFolders.ts
+++ b/features/add/hooks/useFolders.ts
@@ -1,16 +1,15 @@
 import { useState, useEffect } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import TasksDatabase from '@/lib/TaskDatabase';
 import type { Task } from '../types';
-import { STORAGE_KEY } from '../constants';
 
 export const useFolders = (trigger?: unknown): string[] => {
   const [folders, setFolders] = useState<string[]>([]);
 
   useEffect(() => {
     const load = async () => {
-      const raw = await AsyncStorage.getItem(STORAGE_KEY);
-      // JSON.parse の結果を Task[] として扱う
-      const tasks: Task[] = raw ? (JSON.parse(raw) as Task[]) : [];
+      await TasksDatabase.initialize();
+      const raw = await TasksDatabase.getAllTasks();
+      const tasks: Task[] = raw.map(r => JSON.parse(r) as Task);
       const unique = Array.from(
         new Set(
           tasks

--- a/features/add/hooks/useSaveTask.ts
+++ b/features/add/hooks/useSaveTask.ts
@@ -1,7 +1,7 @@
 // app/features/add/hooks/useSaveTask.ts
 import { useCallback } from 'react';
 import { Alert } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import TasksDatabase from '@/lib/TaskDatabase';
 import uuid from 'react-native-uuid';
 import Toast from 'react-native-toast-message';
 import { useRouter } from 'expo-router';
@@ -120,12 +120,8 @@ export const useSaveTask = ({
     };
 
     try {
-      const raw = await AsyncStorage.getItem(STORAGE_KEY);
-      const tasks: Task[] = raw ? JSON.parse(raw) : [];
-      await AsyncStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify([...tasks, newTask])
-      );
+      await TasksDatabase.initialize();
+      await TasksDatabase.saveTask(newTask as any);
       Toast.show({ type: 'success', text1: t('add_task.task_added_successfully', 'タスクを追加しました') });
       clearForm();
       router.replace('/(tabs)/tasks');

--- a/features/add_edit/screens/EditDraftScreen.tsx
+++ b/features/add_edit/screens/EditDraftScreen.tsx
@@ -29,6 +29,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { DateTimePickerAndroid } from '@react-native-community/datetimepicker';
 import * as ImagePicker from 'expo-image-picker';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import TasksDatabase from '@/lib/TaskDatabase';
 import uuid from 'react-native-uuid';
 import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
@@ -435,9 +436,8 @@ export default function EditDraftScreen() {
       customUnit,
       customAmount,
     };
-    const raw = await AsyncStorage.getItem(STORAGE_KEY);
-    const tasks = raw ? JSON.parse(raw) : [];
-    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify([newTask, ...tasks]));
+    await TasksDatabase.initialize();
+    await TasksDatabase.saveTask(newTask as any);
 
     const draftsRaw = await AsyncStorage.getItem(DRAFTS_KEY);
     const drafts = draftsRaw ? JSON.parse(draftsRaw) : [];

--- a/features/add_edit/screens/EditTaskScreen.tsx
+++ b/features/add_edit/screens/EditTaskScreen.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import TasksDatabase from '@/lib/TaskDatabase';
 import { Ionicons } from '@expo/vector-icons';
 import { useUnsavedStore } from '@/hooks/useUnsavedStore';
 import { useAppTheme } from '@/hooks/ThemeContext';
@@ -77,8 +77,9 @@ export default function EditTaskScreen() {
 
   useEffect(() => {
     const load = async () => {
-      const raw = await AsyncStorage.getItem('TASKS');
-      const tasks: Task[] = raw ? JSON.parse(raw) : [];
+      await TasksDatabase.initialize();
+      const raw = await TasksDatabase.getAllTasks();
+      const tasks: Task[] = raw.map(r => JSON.parse(r));
       const found = tasks.find(t => t.id === id);
       if (!found) {
         router.back();

--- a/features/growth/GrowthScreen.tsx
+++ b/features/growth/GrowthScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import TasksDatabase from '@/lib/TaskDatabase';
 import { useTranslation } from 'react-i18next';
 import { useAppTheme } from '@/hooks/ThemeContext';
 import { FontSizeContext } from '@/context/FontSizeContext';
@@ -20,8 +20,9 @@ export default function GrowthScreen() {
   useEffect(() => {
     const load = async () => {
       try {
-        const raw = await AsyncStorage.getItem(TASKS_KEY);
-        const tasks: Task[] = raw ? JSON.parse(raw) : [];
+        await TasksDatabase.initialize();
+        const raw = await TasksDatabase.getAllTasks();
+        const tasks: Task[] = raw.map(r => JSON.parse(r));
         setCompletedCount(tasks.filter(t => t.completedAt).length);
       } catch {
         setCompletedCount(0);


### PR DESCRIPTION
## Summary
- drop AsyncStorage usage when saving or updating tasks
- read/write tasks via `TasksDatabase`
- keep folder order in AsyncStorage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843c5e0273483268796ce78f8c2e960