### PR TITLE
Fix SQLite transaction error

### DIFF
--- a/lib/TaskDatabase.ts
+++ b/lib/TaskDatabase.ts
@@ -5,10 +5,11 @@ export type TaskRecord = {
   [key: string]: any;
 };
 
-const db =
-  'openDatabaseSync' in SQLite
-    ? (SQLite as any).openDatabaseSync('tasks.db')
-    : (SQLite as any).openDatabase('tasks.db');
+// expo-sqlite の openDatabaseSync は新しい API を返しますが
+// 既存コードでは transaction メソッドが必要な従来 API を利用しています。
+// openDatabaseSync を使うと `db.transaction` が存在せずエラーとなるため
+// 常に openDatabase を使用するように戻します。
+const db = SQLite.openDatabase('tasks.db');
     
 const run = <T>(
   callback: (tx: SQLite.SQLTransaction) => void


### PR DESCRIPTION
## Summary
- fix expo-sqlite usage so `db.transaction` is defined

## Testing
- `npm test --silent` *(fails: Cannot find module '@testing-library/react-native')*
- `npm run lint` *(fails: Missing script 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_6843dfd16f6c83268f438b0a6d930f38