### PR TITLE
Fix SQLite import

### DIFF
--- a/lib/TaskDatabase.ts
+++ b/lib/TaskDatabase.ts
@@ -1,14 +1,18 @@
-import * as SQLite from 'expo-sqlite';
+// expo-sqlite v15 以降では旧 API を利用する場合、"expo-sqlite/legacy" を
+// インポートする必要がある。これを行わないと openDatabase() が未定義と
+// なり、db.transaction が実行できないエラーが発生する。
+import * as SQLite from 'expo-sqlite/legacy';
 
 export type TaskRecord = {
   id: string;
   [key: string]: any;
 };
 
-const db =
-  'openDatabaseSync' in SQLite
-    ? (SQLite as any).openDatabaseSync('tasks.db')
-    : (SQLite as any).openDatabase('tasks.db');
+// expo-sqlite の openDatabaseSync は新しい API を返しますが
+// 既存コードでは transaction メソッドが必要な従来 API を利用しています。
+// openDatabaseSync を使うと `db.transaction` が存在せずエラーとなるため
+// 常に openDatabase を使用するように戻します。
+const db = SQLite.openDatabase('tasks.db');
     
 const run = <T>(
   callback: (tx: SQLite.SQLTransaction) => void


### PR DESCRIPTION
## Summary
- import legacy expo-sqlite API so openDatabase supports transactions

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: Missing script 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_6843dfd16f6c83268f438b0a6d930f38