### PR TITLE
Fix SQLite legacy import for Hermes

### DIFF
--- a/lib/TaskDatabase.ts
+++ b/lib/TaskDatabase.ts
@@ -1,7 +1,8 @@
-// expo-sqlite v15 以降では旧 API を利用する場合、"expo-sqlite/legacy" を
-// インポートする必要がある。これを行わないと openDatabase() が未定義と
-// なり、db.transaction が実行できないエラーが発生する。
-import * as SQLite from 'expo-sqlite';
+// expo-sqlite v15 以降で従来の API を利用するには "expo-sqlite/legacy"
+// からインポートする必要があります。これを行わないと openDatabase()
+// が未定義となり、db.transaction が実行できないエラーが発生します。
+// そのためここでは legacy モジュールからインポートします。
+import * as SQLite from 'expo-sqlite/legacy';
 
 export type TaskRecord = {
   id: string;


### PR DESCRIPTION
## Summary
- fix expo SQLite import for Hermes-based bundling

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843e9cd7fc8832699f33dc33a280016