### PR TITLE
UI adjustments

### DIFF
--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -28,7 +28,8 @@ const CALENDAR_BG_KEY = '@calendar_background_id';
 const WEEKDAY_COLOR = '#888888';
 const SUNDAY_COLOR = '#FF6666';
 const SATURDAY_COLOR = '#66B2FF';
-const HEADER_HEIGHT = 30;
+// 曜日欄の高さに合わせて短くする
+const HEADER_HEIGHT = 24;
 
 export default function CalendarPage() {
   const { t } = useTranslation();
@@ -220,7 +221,7 @@ export default function CalendarPage() {
                      <Text style={styles.todayButtonText}>{t('common.today')}</Text>
                  </Pressable>
                  <Pressable onPress={toggleView} style={styles.toggleButton}>
-                     <Ionicons name={viewType === 'list' ? 'calendar' : 'list'} size={20} color="#fff" />
+                     <Ionicons name={viewType === 'list' ? 'list' : 'calendar'} size={20} color="#fff" />
                  </Pressable>
              </View>
         </View>

--- a/features/calendar/components/SkiaCalendar.tsx
+++ b/features/calendar/components/SkiaCalendar.tsx
@@ -16,7 +16,8 @@ const FONT_PATH_REGULAR = require('@/assets/fonts/NotoSansJP-Regular.ttf');
 // カレンダー表示用のパディング量（大表示時は0）
 // パディングなしで全幅表示
 const PADDING = 0;
-const HEADER_HEIGHT = 30; // 曜日表示欄を少し細くする
+// 曜日欄の高さをさらにコンパクトに
+const HEADER_HEIGHT = 24;
 const TASK_BAR_HEIGHT = 5;
 const TASK_BAR_MARGIN = 3;
 const EVENT_BAR_HEIGHT = 20;

--- a/features/settings/components/LanguageSelector.tsx
+++ b/features/settings/components/LanguageSelector.tsx
@@ -1,15 +1,20 @@
 // app/language.tsx
 import React from 'react'
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
+import { View, Text, TouchableOpacity, StyleSheet, Platform } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { useTranslation } from 'react-i18next'
+import { Ionicons } from '@expo/vector-icons'
 import { changeAppLanguage } from '@/lib/i18n'
+import { useAppTheme } from '@/hooks/ThemeContext'
 
 export default function LanguageScreen() {
   const { i18n, t } = useTranslation()
   const router = useRouter()
   const currentLang = i18n.language
+  const { colorScheme, subColor } = useAppTheme()
+  const isDark = colorScheme === 'dark'
+  const styles = createLanguageStyles(isDark, subColor)
 
   const changeLanguage = async (lng: string) => {
     await changeAppLanguage(lng)
@@ -19,10 +24,11 @@ export default function LanguageScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.appBar}>
-        <TouchableOpacity onPress={() => router.back()}>
-          <Text style={styles.backButton}>←</Text>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <Ionicons name="arrow-back" size={24} color={subColor} />
         </TouchableOpacity>
         <Text style={styles.appBarTitle}>{t('settings.select_language')}</Text>
+        <View style={styles.appBarActionPlaceholder} />
       </View>
 
       <View style={styles.options}>
@@ -43,13 +49,53 @@ export default function LanguageScreen() {
   )
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#fff' },
-  appBar: { flexDirection: 'row', alignItems: 'center', height: 56, paddingHorizontal: 16 },
-  backButton: { fontSize: 24, marginRight: 12 },
-  appBarTitle: { fontSize: 20, fontWeight: 'bold' },
-  options: { marginTop: 32, paddingHorizontal: 20 },
-  optionRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingVertical: 16 },
-  optionText: { fontSize: 18 },
-  checkmark: { fontSize: 18 },
-})
+const createLanguageStyles = (isDark: boolean, subColor: string) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: isDark ? '#000000' : '#F2F2F7',
+    },
+    appBar: {
+      height: Platform.OS === 'ios' ? 44 : 56,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 8,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.2)',
+      backgroundColor: isDark ? '#1C1C1E' : '#F9F9F9',
+    },
+    backButton: {
+      padding: 8,
+      marginRight: 8,
+    },
+    appBarTitle: {
+      fontSize: Platform.OS === 'ios' ? 17 : 20,
+      fontWeight: Platform.OS === 'ios' ? '600' : '500',
+      color: isDark ? '#FFFFFF' : '#000000',
+      textAlign: 'center',
+      flex: 1,
+    },
+    appBarActionPlaceholder: {
+      width: (Platform.OS === 'ios' ? 32 : 24) + 8,
+    },
+    options: {
+      padding: 20,
+    },
+    optionRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingVertical: 16,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderColor: isDark ? '#3A3A3C' : '#E0E0E0',
+    },
+    optionText: {
+      fontSize: 18,
+      color: isDark ? '#EFEFF0' : '#1C1C1E',
+    },
+    checkmark: {
+      fontSize: 18,
+      color: subColor,
+    },
+  })


### PR DESCRIPTION
## Summary
- shorten calendar header height
- reverse icons for switching calendar views
- redesign language selection screen to match other pages

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68440e007d9883269d7f14d944b71d38