### PR TITLE
Fix growth screen freeze

### DIFF
--- a/features/growth/GrowthScreen.tsx
+++ b/features/growth/GrowthScreen.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import { useプレイヤーデータ } from './フック/useプレイヤーデータ';
+// The hook file lives under hooks/Useplayerdata.ts
+import { useプレイヤーデータ } from './hooks/Useplayerdata';
 
 export default function GrowthScreen() {
   const { isReady, gold, addGold } = useプレイヤーデータ();

--- a/features/growth/data/playerdatabase.ts
+++ b/features/growth/data/playerdatabase.ts
@@ -5,7 +5,15 @@ import { Award, Scene, PlayerItem } from '../型定義';
 const openDatabase = SQLite.openDatabase ?? (() => {
   console.warn('SQLite is not available in this environment');
   return {
-    transaction: () => {},
+    transaction: (callback: SQLite.SQLTransactionCallback, _err?: SQLite.SQLTransactionErrorCallback, success?: SQLite.SQLTransactionSuccessCallback) => {
+      const tx = {
+        executeSql: (_sql: string, _params?: any[], cb?: any) => {
+          cb?.(null, { rows: { length: 0, item: () => ({}) } });
+        },
+      } as unknown as SQLite.SQLTransaction;
+      callback(tx);
+      success?.();
+    },
   } as unknown as SQLite.SQLiteDatabase;
 });
 

--- a/features/growth/hooks/Useplayerdata.ts
+++ b/features/growth/hooks/Useplayerdata.ts
@@ -1,6 +1,7 @@
 // features/growth/フック/useプレイヤーデータ.ts
 import { useState, useEffect, useCallback } from 'react';
-import { initializeDatabase, getCurrency, updateCurrency } from '../データ/プレイヤーデータベース';
+// Use the English path to avoid module resolution issues
+import { initializeDatabase, getCurrency, updateCurrency } from '../data/playerdatabase';
 
 export const useプレイヤーデータ = () => {
   const [isReady, setIsReady] = useState(false);


### PR DESCRIPTION
## Summary
- make the growth hook import its DB helpers using the English path
- adjust GrowthScreen import path
- provide a no-op SQLite fallback that still resolves
- add trailing newlines

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68444fce44608326bb61f26e02a05385