### PR TITLE
Fix growth feature import cycles

### DIFF
--- a/features/growth/GrowthScreen.tsx
+++ b/features/growth/GrowthScreen.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import { useプレイヤーデータ } from './フック/useプレイヤーデータ';
+import { useプレイヤーデータ } from './hooks/Useplayerdata';
 
 export default function GrowthScreen() {
   const { isReady, gold, addGold } = useプレイヤーデータ();

--- a/features/growth/data/playerdatabase.ts
+++ b/features/growth/data/playerdatabase.ts
@@ -1,6 +1,6 @@
 // features/growth/データ/プレイヤーデータベース.ts
 import * as SQLite from 'expo-sqlite';
-import { Award, Scene, PlayerItem } from '../型定義';
+import { Award, Scene, PlayerItem } from '../type';
 
 const openDatabase = SQLite.openDatabase ?? (() => {
   console.warn('SQLite is not available in this environment');

--- a/features/growth/hooks/Useplayerdata.ts
+++ b/features/growth/hooks/Useplayerdata.ts
@@ -1,6 +1,6 @@
 // features/growth/フック/useプレイヤーデータ.ts
 import { useState, useEffect, useCallback } from 'react';
-import { initializeDatabase, getCurrency, updateCurrency } from '../データ/プレイヤーデータベース';
+import { initializeDatabase, getCurrency, updateCurrency } from '../data/playerdatabase';
 
 export const useプレイヤーデータ = () => {
   const [isReady, setIsReady] = useState(false);

--- a/features/growth/index.tsx
+++ b/features/growth/index.tsx
@@ -1,6 +1,4 @@
 //C:\Users\fukur\task-app\app\app\(tabs)\growth\index.tsx
-import GrowthScreen from '@/features/growth';
+import GrowthScreen from './GrowthScreen';
 
-export default function GrowthTab() {
-  return <GrowthScreen />;
-}
+export default GrowthScreen;


### PR DESCRIPTION
## Summary
- fix import path for GrowthScreen
- update paths for GrowthScreen hook and database modules
- adjust player database import path

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684450514abc8326b47ad20f59f5afe4