### PR TITLE
Add growth mode foundation

### DIFF
--- a/features/growth/GrowthScreen.tsx
+++ b/features/growth/GrowthScreen.tsx
@@ -4,9 +4,12 @@ import { View, StyleSheet, Button } from 'react-native';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import { usePlayerData } from '@/features/growth/hooks/usePlayerData';
+import SceneViewer from '@/features/growth/component/SceneViewer';
+import FocusTimer from '@/features/growth/component/FocusTimer';
 
 export default function GrowthScreen() {
-  const { isReady, gold, addGold } = usePlayerData();
+  const { isReady, gold, addGold, growthPoints, addGrowthPoints } =
+    usePlayerData();
 
   if (!isReady) {
     return (
@@ -22,8 +25,11 @@ export default function GrowthScreen() {
 
       <View style={styles.statusContainer}>
         <ThemedText style={styles.goldText}>所持ゴールド: {gold} G</ThemedText>
+        <ThemedText style={styles.goldText}>成長ポイント: {growthPoints}</ThemedText>
       </View>
 
+      <SceneViewer growth={growthPoints} />
+      <FocusTimer onComplete={() => addGrowthPoints(1)} />
       <Button title="ゴールドを10増やす" onPress={() => addGold(10)} />
 
     </ThemedView>

--- a/features/growth/component/FocusTimer.tsx
+++ b/features/growth/component/FocusTimer.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+
+type Props = {
+  initialSeconds?: number;
+  onComplete?: () => void;
+};
+
+export default function FocusTimer({ initialSeconds = 1500, onComplete }: Props) {
+  const [secondsLeft, setSecondsLeft] = useState(initialSeconds);
+  const [isRunning, setIsRunning] = useState(false);
+
+  useEffect(() => {
+    if (!isRunning) return;
+    if (secondsLeft === 0) {
+      setIsRunning(false);
+      onComplete?.();
+      return;
+    }
+    const id = setInterval(() => {
+      setSecondsLeft((s) => s - 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [isRunning, secondsLeft]);
+
+  const reset = () => {
+    setIsRunning(false);
+    setSecondsLeft(initialSeconds);
+  };
+
+  const minutes = Math.floor(secondsLeft / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = Math.floor(secondsLeft % 60)
+    .toString()
+    .padStart(2, '0');
+
+  return (
+    <View style={styles.container}>
+      <ThemedText type="title">{`${minutes}:${seconds}`}</ThemedText>
+      <View style={styles.buttons}>
+        <Button
+          title={isRunning ? 'Pause' : 'Start'}
+          onPress={() => setIsRunning((v) => !v)}
+        />
+        <Button title="Reset" onPress={reset} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: 10,
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+});

--- a/features/growth/component/SceneViewer.tsx
+++ b/features/growth/component/SceneViewer.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { ImageBackground, StyleSheet, View } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { Audio } from 'expo-av';
+import { ThemedText } from '@/components/ThemedText';
+import { useSceneState } from '@/features/growth/hooks/UseSceneState';
+
+export default function SceneViewer({ growth }: { growth: number }) {
+  const { scenes, selectedSceneId, setSelectedSceneId, selectedScene } =
+    useSceneState();
+  const [sound, setSound] = useState<Audio.Sound | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (sound) {
+        await sound.stopAsync();
+        await sound.unloadAsync();
+      }
+      const { sound: newSound } = await Audio.Sound.createAsync(
+        selectedScene.bgmPath,
+      );
+      setSound(newSound);
+      await newSound.playAsync();
+    };
+
+    load();
+    return () => {
+      sound?.unloadAsync();
+    };
+  }, [selectedSceneId]);
+
+  const size = 200 + growth * 10;
+
+  return (
+    <View>
+      <Picker
+        selectedValue={selectedSceneId}
+        onValueChange={(itemValue) => setSelectedSceneId(itemValue)}>
+        {scenes.map((scene) => (
+          <Picker.Item key={scene.id} label={scene.name} value={scene.id} />
+        ))}
+      </Picker>
+      <ImageBackground
+        source={selectedScene.imagePath}
+        style={[styles.image, { width: size, height: size }]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  image: {
+    resizeMode: 'contain',
+    alignSelf: 'center',
+  },
+});

--- a/features/growth/data/playerdatabase.ts
+++ b/features/growth/data/playerdatabase.ts
@@ -20,6 +20,8 @@ const initializeDatabase = async (): Promise<void> => {
       CREATE TABLE IF NOT EXISTS player_items (id TEXT PRIMARY KEY NOT NULL, quantity INTEGER);
       CREATE TABLE IF NOT EXISTS player_currency (id TEXT PRIMARY KEY NOT NULL, amount INTEGER);
       INSERT OR IGNORE INTO player_currency (id, amount) VALUES ('gold', 0);
+      CREATE TABLE IF NOT EXISTS player_progress (id TEXT PRIMARY KEY NOT NULL, points INTEGER);
+      INSERT OR IGNORE INTO player_progress (id, points) VALUES ('growth', 0);
     `);
 };
 
@@ -40,4 +42,21 @@ const updateCurrency = async (id: string, newAmount: number): Promise<void> => {
     );
 };
 
-export { initializeDatabase, getCurrency, updateCurrency };
+const getGrowthPoints = async (): Promise<number> => {
+    const database = await getDb();
+    const result = await database.getFirstAsync<{ points: number }>(
+        'SELECT points FROM player_progress WHERE id = ?;',
+        ['growth']
+    );
+    return result?.points ?? 0;
+};
+
+const updateGrowthPoints = async (newPoints: number): Promise<void> => {
+    const database = await getDb();
+    await database.runAsync(
+        'UPDATE player_progress SET points = ? WHERE id = ?;',
+        [newPoints, 'growth']
+    );
+};
+
+export { initializeDatabase, getCurrency, updateCurrency, getGrowthPoints, updateGrowthPoints };

--- a/features/growth/hooks/UseSceneState.ts
+++ b/features/growth/hooks/UseSceneState.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import type { Scene } from '@/features/growth/types';
+
+const scenes: Scene[] = [
+  {
+    id: 'forest',
+    name: '育つ森',
+    description: '静かな森が成長します',
+    imagePath: require('../assets/scene/Silent Forest/画像.png'),
+    bgmPath: require('../assets/scene/Silent Forest/BGM.mp3'),
+  },
+  {
+    id: 'plateau',
+    name: '高原',
+    description: '広がる高原の風景',
+    imagePath: require('../assets/scene/plateau/画像.png'),
+    bgmPath: require('../assets/scene/plateau/BGM.mp3'),
+  },
+];
+
+export const useSceneState = () => {
+  const [selectedSceneId, setSelectedSceneId] = useState<string>(scenes[0].id);
+
+  const selectedScene = scenes.find((s) => s.id === selectedSceneId) ?? scenes[0];
+
+  return {
+    scenes,
+    selectedSceneId,
+    setSelectedSceneId,
+    selectedScene,
+  };
+};
+
+export type { Scene } from '@/features/growth/types';

--- a/features/growth/hooks/usePlayerData.ts
+++ b/features/growth/hooks/usePlayerData.ts
@@ -1,19 +1,28 @@
 // features/growth/hooks/usePlayerData.ts
 import { useState, useEffect, useCallback } from 'react';
-import { initializeDatabase, getCurrency, updateCurrency } from '@/features/growth/data/playerDatabase';
+import {
+  initializeDatabase,
+  getCurrency,
+  updateCurrency,
+  getGrowthPoints,
+  updateGrowthPoints,
+} from '@/features/growth/data/playerDatabase';
 
 export const usePlayerData = () => {
   const [isReady, setIsReady] = useState(false);
   const [gold, setGold] = useState(0);
+  const [growthPoints, setGrowthPoints] = useState(0);
 
   useEffect(() => {
     const setup = async () => {
       try {
         await initializeDatabase();
         const initialGold = await getCurrency('gold');
+        const initialGrowth = await getGrowthPoints();
         setGold(initialGold);
+        setGrowthPoints(initialGrowth);
       } catch (e) {
-        console.error("Database setup failed", e);
+        console.error('Database setup failed', e);
       } finally {
         setIsReady(true);
       }
@@ -27,5 +36,14 @@ export const usePlayerData = () => {
     setGold(newGold);
   }, [gold]);
 
-  return { isReady, gold, addGold };
+  const addGrowthPoints = useCallback(
+    async (amount: number) => {
+      const newPoints = growthPoints + amount;
+      await updateGrowthPoints(newPoints);
+      setGrowthPoints(newPoints);
+    },
+    [growthPoints],
+  );
+
+  return { isReady, gold, addGold, growthPoints, addGrowthPoints };
 };

--- a/features/growth/types.ts
+++ b/features/growth/types.ts
@@ -4,8 +4,8 @@ export interface Scene {
   id: string;
   name: string;
   description: string;
-  imagePath: string;
-  bgmPath: string;
+  imagePath: any;
+  bgmPath: any;
 }
 
 export interface Award {


### PR DESCRIPTION
## Summary
- implement basic FocusTimer with start/stop/reset
- create SceneViewer with simple theme selection and BGM playback
- manage current scene state via `useSceneState`
- store player progress in SQLite through updated playerDatabase
- track growth points and expose via usePlayerData
- show timer, scene viewer and growth status in GrowthScreen

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Missing script 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_684504870e048326a7b6f3d65249f8ea