### PR TITLE
Implement timer and basic growth logic

### DIFF
--- a/features/growth/GrowthScreen.tsx
+++ b/features/growth/GrowthScreen.tsx
@@ -4,9 +4,11 @@ import { View, StyleSheet, Button } from 'react-native';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import { usePlayerData } from '@/features/growth/hooks/UsePlayerData';
+import SceneViewer from '@/features/growth/component/SceneViewer';
+import FocusTimer from '@/features/growth/component/FocusTimer';
 
 export default function GrowthScreen() {
-  const { isReady, gold, addGold } = usePlayerData();
+  const { isReady, gold, growth, addGold, addGrowth } = usePlayerData();
 
   if (!isReady) {
     return (
@@ -20,12 +22,16 @@ export default function GrowthScreen() {
     <ThemedView style={styles.container}>
       <ThemedText type="title">成長の世界</ThemedText>
 
+      <SceneViewer growth={growth} />
+
       <View style={styles.statusContainer}>
         <ThemedText style={styles.goldText}>所持ゴールド: {gold} G</ThemedText>
+        <ThemedText style={styles.goldText}>成長ポイント: {growth}</ThemedText>
       </View>
 
-      <Button title="ゴールドを10増やす" onPress={() => addGold(10)} />
+      <FocusTimer onComplete={() => addGrowth(1)} />
 
+      <Button title="ゴールドを10増やす" onPress={() => addGold(10)} />
     </ThemedView>
   );
 }
@@ -41,9 +47,11 @@ const styles = StyleSheet.create({
     padding: 10,
     borderRadius: 8,
     backgroundColor: 'rgba(0,0,0,0.1)',
+    alignItems: 'center',
+    gap: 4,
   },
   goldText: {
     fontSize: 18,
     fontWeight: 'bold',
-  }
+  },
 });

--- a/features/growth/component/FocusTimer.tsx
+++ b/features/growth/component/FocusTimer.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+interface FocusTimerProps {
+  initialSeconds?: number;
+  onComplete?: () => void;
+}
+
+const FocusTimer: React.FC<FocusTimerProps> = ({ initialSeconds = 25 * 60, onComplete }) => {
+  const [secondsLeft, setSecondsLeft] = useState(initialSeconds);
+  const [isRunning, setIsRunning] = useState(false);
+  const intervalRef = useRef<NodeJS.Timer | null>(null);
+
+  useEffect(() => {
+    if (isRunning) {
+      intervalRef.current = setInterval(() => {
+        setSecondsLeft((prev) => {
+          if (prev <= 1) {
+            clearInterval(intervalRef.current!);
+            intervalRef.current = null;
+            setIsRunning(false);
+            onComplete?.();
+            return initialSeconds;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [isRunning]);
+
+  const toggle = () => setIsRunning((prev) => !prev);
+
+  const reset = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setSecondsLeft(initialSeconds);
+    setIsRunning(false);
+  };
+
+  const minutes = Math.floor(secondsLeft / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = (secondsLeft % 60).toString().padStart(2, '0');
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.time}>{`${minutes}:${seconds}`}</Text>
+      <View style={styles.buttons}>
+        <Button title={isRunning ? 'Pause' : 'Start'} onPress={toggle} />
+        <Button title="Reset" onPress={reset} />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: 10,
+  },
+  time: {
+    fontSize: 32,
+    fontWeight: 'bold',
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+});
+
+export default FocusTimer;

--- a/features/growth/component/SceneViewer.tsx
+++ b/features/growth/component/SceneViewer.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Image, StyleSheet } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { useSceneState } from '../hooks/UseSceneState';
+
+const scenes = [
+  {
+    id: 'Silent Forest',
+    name: '静かな森',
+    image: require('../assets/scene/Silent Forest/画像.png'),
+  },
+  {
+    id: 'plateau',
+    name: '高原',
+    image: require('../assets/scene/plateau/画像.png'),
+  },
+];
+
+type Props = {
+  growth: number;
+};
+
+const SceneViewer: React.FC<Props> = ({ growth }) => {
+  const { sceneId, setSceneId } = useSceneState();
+  const scene = scenes.find((s) => s.id === sceneId) ?? scenes[0];
+
+  return (
+    <View style={styles.container}>
+      <Picker selectedValue={sceneId} onValueChange={(v) => setSceneId(String(v))}>
+        {scenes.map((s) => (
+          <Picker.Item label={s.name} value={s.id} key={s.id} />
+        ))}
+      </Picker>
+      <Image
+        source={scene.image}
+        style={[styles.image, { transform: [{ scale: 1 + growth * 0.05 }] }]}
+        resizeMode="contain"
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    width: '100%',
+  },
+  image: {
+    width: '100%',
+    height: 200,
+  },
+});
+
+export default SceneViewer;

--- a/features/growth/data/playerDatabase.tsx
+++ b/features/growth/data/playerDatabase.tsx
@@ -12,32 +12,30 @@ const getDb = async (): Promise<SQLiteDatabase> => {
 };
 
 const initializeDatabase = async (): Promise<void> => {
-    const database = await getDb();
-    await database.execAsync(`
-      PRAGMA journal_mode = WAL;
-      CREATE TABLE IF NOT EXISTS unlocked_scenes (id TEXT PRIMARY KEY NOT NULL);
-      CREATE TABLE IF NOT EXISTS unlocked_awards (id TEXT PRIMARY KEY NOT NULL, unlocked_at INTEGER);
-      CREATE TABLE IF NOT EXISTS player_items (id TEXT PRIMARY KEY NOT NULL, quantity INTEGER);
-      CREATE TABLE IF NOT EXISTS player_currency (id TEXT PRIMARY KEY NOT NULL, amount INTEGER);
-      INSERT OR IGNORE INTO player_currency (id, amount) VALUES ('gold', 0);
-    `);
+  const database = await getDb();
+  await database.execAsync(`
+    PRAGMA journal_mode = WAL;
+    CREATE TABLE IF NOT EXISTS unlocked_scenes (id TEXT PRIMARY KEY NOT NULL);
+    CREATE TABLE IF NOT EXISTS unlocked_awards (id TEXT PRIMARY KEY NOT NULL, unlocked_at INTEGER);
+    CREATE TABLE IF NOT EXISTS player_items (id TEXT PRIMARY KEY NOT NULL, quantity INTEGER);
+    CREATE TABLE IF NOT EXISTS player_currency (id TEXT PRIMARY KEY NOT NULL, amount INTEGER);
+    INSERT OR IGNORE INTO player_currency (id, amount) VALUES ('gold', 0);
+    INSERT OR IGNORE INTO player_currency (id, amount) VALUES ('growth', 0);
+  `);
 };
 
 const getCurrency = async (id: string): Promise<number> => {
-    const database = await getDb();
-    const result = await database.getFirstAsync<{ amount: number }>(
-        'SELECT amount FROM player_currency WHERE id = ?;',
-        [id]
-    );
-    return result?.amount ?? 0;
+  const database = await getDb();
+  const result = await database.getFirstAsync<{ amount: number }>(
+    'SELECT amount FROM player_currency WHERE id = ?;',
+    [id]
+  );
+  return result?.amount ?? 0;
 };
 
 const updateCurrency = async (id: string, newAmount: number): Promise<void> => {
-    const database = await getDb();
-    await database.runAsync(
-        'UPDATE player_currency SET amount = ? WHERE id = ?;',
-        [newAmount, id]
-    );
+  const database = await getDb();
+  await database.runAsync('UPDATE player_currency SET amount = ? WHERE id = ?;', [newAmount, id]);
 };
 
 export { initializeDatabase, getCurrency, updateCurrency };

--- a/features/growth/hooks/UsePlayerData.tsx
+++ b/features/growth/hooks/UsePlayerData.tsx
@@ -5,15 +5,18 @@ import { initializeDatabase, getCurrency, updateCurrency } from '@/features/grow
 export const usePlayerData = () => {
   const [isReady, setIsReady] = useState(false);
   const [gold, setGold] = useState(0);
+  const [growth, setGrowth] = useState(0);
 
   useEffect(() => {
     const setup = async () => {
       try {
         await initializeDatabase();
         const initialGold = await getCurrency('gold');
+        const initialGrowth = await getCurrency('growth');
         setGold(initialGold);
+        setGrowth(initialGrowth);
       } catch (e) {
-        console.error("Database setup failed", e);
+        console.error('Database setup failed', e);
       } finally {
         setIsReady(true);
       }
@@ -27,5 +30,11 @@ export const usePlayerData = () => {
     setGold(newGold);
   }, [gold]);
 
-  return { isReady, gold, addGold };
+  const addGrowth = useCallback(async (amount: number) => {
+    const newGrowth = growth + amount;
+    await updateCurrency('growth', newGrowth);
+    setGrowth(newGrowth);
+  }, [growth]);
+
+  return { isReady, gold, growth, addGold, addGrowth };
 };

--- a/features/growth/hooks/UseSceneState.ts
+++ b/features/growth/hooks/UseSceneState.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+export type SceneId = 'Silent Forest' | 'plateau';
+
+type SceneStore = {
+  sceneId: SceneId;
+  setSceneId: (id: SceneId) => void;
+};
+
+export const useSceneState = create<SceneStore>((set) => ({
+  sceneId: 'Silent Forest',
+  setSceneId: (id) => set({ sceneId: id }),
+}));


### PR DESCRIPTION
## Summary
- build simple focus timer with start/pause/reset
- add basic scene viewer with theme picker
- manage selected theme state with zustand
- track gold and growth points in SQLite db
- visualize growth on GrowthScreen

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_684509683b108326a834e27cc1a4dfea