### PR TITLE
Fix asset paths for growth images

### DIFF
--- a/features/growth/GrowScreen.tsx
+++ b/features/growth/GrowScreen.tsx
@@ -171,7 +171,7 @@ export default function GrowthScreen() {
     );
   }
 
-  const PLACEHOLDER_IMAGE_FALLBACK = require('../../../assets/images/growth/placeholder.png');
+  const PLACEHOLDER_IMAGE_FALLBACK = require('../../assets/images/growth/placeholder.png');
   const currentThemeImage = currentThemeAsset?.image || PLACEHOLDER_IMAGE_FALLBACK;
 
   return (

--- a/features/growth/GrowScreen.tsx
+++ b/features/growth/GrowScreen.tsx
@@ -171,7 +171,8 @@ export default function GrowthScreen() {
     );
   }
 
-  const PLACEHOLDER_IMAGE_FALLBACK = require('../../assets/images/growth/placeholder.png');
+  // 画像アセットへの参照は `@` エイリアスを利用
+  const PLACEHOLDER_IMAGE_FALLBACK = require('@/assets/images/growth/placeholder.png');
   const currentThemeImage = currentThemeAsset?.image || PLACEHOLDER_IMAGE_FALLBACK;
 
   return (

--- a/features/growth/GrowScreen.tsx
+++ b/features/growth/GrowScreen.tsx
@@ -171,7 +171,7 @@ export default function GrowthScreen() {
     );
   }
 
-  const PLACEHOLDER_IMAGE_FALLBACK = require('../../assets/images/growth/placeholder.png');
+  const PLACEHOLDER_IMAGE_FALLBACK = require('../../../assets/images/growth/placeholder.png');
   const currentThemeImage = currentThemeAsset?.image || PLACEHOLDER_IMAGE_FALLBACK;
 
   return (

--- a/features/growth/themes/index.ts
+++ b/features/growth/themes/index.ts
@@ -3,7 +3,9 @@
 import { Theme, GrowthStage, UserThemeProgress } from './types'; // Theme, GrowthStage, UserThemeProgressをtypes.tsからインポート
 
 // ダミー画像として使用するプレースホルダー画像
-const PLACEHOLDER_IMAGE = require('../../../assets/images/growth/placeholder.png'); // 仮のパス
+// 画像アセットはプロジェクト直下の assets 配下に置かれている
+// import 時には `@` エイリアスを使ってルートから参照する
+const PLACEHOLDER_IMAGE = require('@/assets/images/growth/placeholder.png');
 
 export const THEMES: Theme[] = [
   {
@@ -12,11 +14,11 @@ export const THEMES: Theme[] = [
     description: '森の穏やかな精霊が宿るテーマです。',
     locked: false,
     growthStages: {
-      seed: { image: require('../../../assets/images/growth/forest_spirit/seed.png') },
-      sprout: { image: require('../../../assets/images/growth/forest_spirit/sprout.png') },
-      young: { image: require('../../../assets/images/growth/forest_spirit/young.png') },
-      mature: { image: require('../../../assets/images/growth/forest_spirit/mature.png') },
-      ancient: { image: require('../../../assets/images/growth/forest_spirit/ancient.png') },
+      seed: { image: PLACEHOLDER_IMAGE },
+      sprout: { image: PLACEHOLDER_IMAGE },
+      young: { image: PLACEHOLDER_IMAGE },
+      mature: { image: PLACEHOLDER_IMAGE },
+      ancient: { image: PLACEHOLDER_IMAGE },
     },
   },
   {
@@ -25,11 +27,11 @@ export const THEMES: Theme[] = [
     description: '深海の力が宿るテーマです。',
     locked: true,
     growthStages: {
-      seed: { image: require('../../../assets/images/growth/ocean_guardian/seed.png') },
-      sprout: { image: require('../../../assets/images/growth/ocean_guardian/sprout.png') },
-      young: { image: require('../../../assets/images/growth/ocean_guardian/young.png') },
-      mature: { image: require('../../../assets/images/growth/ocean_guardian/mature.png') },
-      ancient: { image: require('../../../assets/images/growth/ocean_guardian/ancient.png') },
+      seed: { image: PLACEHOLDER_IMAGE },
+      sprout: { image: PLACEHOLDER_IMAGE },
+      young: { image: PLACEHOLDER_IMAGE },
+      mature: { image: PLACEHOLDER_IMAGE },
+      ancient: { image: PLACEHOLDER_IMAGE },
     },
   },
   {

--- a/features/growth/themes/index.ts
+++ b/features/growth/themes/index.ts
@@ -3,7 +3,7 @@
 import { Theme, GrowthStage, UserThemeProgress } from './types'; // Theme, GrowthStage, UserThemeProgressをtypes.tsからインポート
 
 // ダミー画像として使用するプレースホルダー画像
-const PLACEHOLDER_IMAGE = require('../../assets/images/growth/placeholder.png'); // 仮のパス
+const PLACEHOLDER_IMAGE = require('../../../assets/images/growth/placeholder.png'); // 仮のパス
 
 export const THEMES: Theme[] = [
   {
@@ -12,11 +12,11 @@ export const THEMES: Theme[] = [
     description: '森の穏やかな精霊が宿るテーマです。',
     locked: false,
     growthStages: {
-      seed: { image: require('../../assets/images/growth/forest_spirit/seed.png') },
-      sprout: { image: require('../../assets/images/growth/forest_spirit/sprout.png') },
-      young: { image: require('../../assets/images/growth/forest_spirit/young.png') },
-      mature: { image: require('../../assets/images/growth/forest_spirit/mature.png') },
-      ancient: { image: require('../../assets/images/growth/forest_spirit/ancient.png') },
+      seed: { image: require('../../../assets/images/growth/forest_spirit/seed.png') },
+      sprout: { image: require('../../../assets/images/growth/forest_spirit/sprout.png') },
+      young: { image: require('../../../assets/images/growth/forest_spirit/young.png') },
+      mature: { image: require('../../../assets/images/growth/forest_spirit/mature.png') },
+      ancient: { image: require('../../../assets/images/growth/forest_spirit/ancient.png') },
     },
   },
   {
@@ -25,11 +25,11 @@ export const THEMES: Theme[] = [
     description: '深海の力が宿るテーマです。',
     locked: true,
     growthStages: {
-      seed: { image: require('../../assets/images/growth/ocean_guardian/seed.png') },
-      sprout: { image: require('../../assets/images/growth/ocean_guardian/sprout.png') },
-      young: { image: require('../../assets/images/growth/ocean_guardian/young.png') },
-      mature: { image: require('../../assets/images/growth/ocean_guardian/mature.png') },
-      ancient: { image: require('../../assets/images/growth/ocean_guardian/ancient.png') },
+      seed: { image: require('../../../assets/images/growth/ocean_guardian/seed.png') },
+      sprout: { image: require('../../../assets/images/growth/ocean_guardian/sprout.png') },
+      young: { image: require('../../../assets/images/growth/ocean_guardian/young.png') },
+      mature: { image: require('../../../assets/images/growth/ocean_guardian/mature.png') },
+      ancient: { image: require('../../../assets/images/growth/ocean_guardian/ancient.png') },
     },
   },
   {


### PR DESCRIPTION
## Summary
- correct relative paths for growth images

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6845396718d0832698ce9abb23994fa0