### PR TITLE
Fix event cache effect loop

### DIFF
--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -103,7 +103,7 @@ export default function CalendarPage() {
     const layout = processMultiDayEvents(allMonthEvents, displayMonth);
     setEventCache(prev => ({ ...prev, [key]: layout }));
     return layout;
-  }, [allMonthEvents, displayMonth, eventCache]);
+  }, [allMonthEvents, displayMonth]);
 
   useEffect(() => {
     const prev = displayMonth.subtract(1, 'month');
@@ -115,7 +115,7 @@ export default function CalendarPage() {
         setEventCache(prevCache => ({ ...prevCache, [key]: layout }));
       }
     });
-  }, [displayMonth, allMonthEvents, eventCache]);
+  }, [displayMonth, allMonthEvents]);
   const dayTasks = useMemo(() => groupedTasks[selectedDate] || [], [groupedTasks, selectedDate]);
   const googleDayEvents = useMemo(() => {
     if (!googleEnabled) return [];


### PR DESCRIPTION
## Summary
- prevent repeated updates when caching calendar events by removing `eventCache` from effect dependencies

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684574b0ce6883269a949fcea798ca61