### PR TITLE
Fix infinite update loop in PhotoPicker

### DIFF
--- a/features/add/components/PhotoPicker.tsx
+++ b/features/add/components/PhotoPicker.tsx
@@ -66,6 +66,8 @@ export const PhotoPicker: React.FC<PhotoPickerProps> = ({
   }, [visible, defaultSelected]);
 
   // --- 2. 権限確認 ---
+  // onCancel は依存不要なので警告を抑制
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (visible && granted === null && isComponentMounted.current) {
       if (isExpoGo) {
@@ -115,7 +117,7 @@ export const PhotoPicker: React.FC<PhotoPickerProps> = ({
         }
       })();
     }
-  }, [visible, granted, onCancel]);
+  }, [visible, granted]);
 
   // --- 3. メディア読み込み関数 ---
   const loadMedia = useCallback(async (isLoadingMore = false) => {


### PR DESCRIPTION
## Summary
- avoid rerunning permission effect due to changing callback

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845775eabc4832690990406a285ac09