### PR TITLE
Remove growth theme button and add focus timer picker

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -91,6 +91,9 @@
     "minutes": "minutes ago",
     "hours": "hours ago",
     "days": "days ago",
+    "hours_label": "Hours",
+    "minutes_label": "Minutes",
+    "seconds_label": "Seconds",
     "today": "Today",
     "info": "Info",
     "notification_title": "Notification",
@@ -386,6 +389,8 @@
   "growth": {
     "title": "Growth",
     "description": "Your tree grows as you complete tasks",
-    "completed": "Completed tasks: {{count}}"
+    "completed": "Completed tasks: {{count}}",
+    "focus_mode_button_start": "Focus Mode",
+    "focus_mode_button_stop": "Stop Focus Mode"
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -95,6 +95,9 @@
     "minutes": "分前",
     "hours": "時間前",
     "days": "日前",
+    "hours_label": "時間",
+    "minutes_label": "分",
+    "seconds_label": "秒",
     "today": "今日",
     "info": "お知らせ",
     "notification_title": "お知らせ",
@@ -407,6 +410,8 @@
     "stop_focus_mode_message": "集中モードを途中で終了すると、今回の集中時間は成長ポイントになりません。",
     "focus_mode_completed_title": "集中モード完了！",
     "focus_mode_completed_message": "{{minutes}}分の集中モードが完了し、{{points}}ポイント獲得しました！",
+    "focus_mode_button_start": "集中モード",
+    "focus_mode_button_stop": "集中モードを終了",
     "store": "ストア",
     "gacha": "ガチャ",
     "gallery": "図鑑"

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -91,6 +91,9 @@
     "minutes": "{{count}}분 전",
     "hours": "{{count}}시간 전",
     "days": "{{count}}일 전",
+    "hours_label": "시간",
+    "minutes_label": "분",
+    "seconds_label": "초",
     "today": "오늘",
     "info": "알림",
     "notification_title": "알림",
@@ -386,6 +389,8 @@
   "growth": {
     "title": "성장",
     "description": "작업을 완료하면 나무가 자라납니다",
-    "completed": "완료한 작업 수: {{count}}"
+    "completed": "완료한 작업 수: {{count}}",
+    "focus_mode_button_start": "집중 모드",
+    "focus_mode_button_stop": "집중 모드 종료"
   }
 }


### PR DESCRIPTION
## Summary
- update translations for timer labels and focus mode buttons
- refactor GrowthScreen timer logic to support hours/minutes/seconds
- replace bottom timer icon with a start/stop focus mode button
- show new wheel pickers for hours, minutes and seconds

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68457878a9a08326a9e74a90b7fae626