### PR TITLE
Refactor growth screen structure

### DIFF
--- a/app/(tabs)/growth/dictionary.tsx
+++ b/app/(tabs)/growth/dictionary.tsx
@@ -1,0 +1,2 @@
+import DictionaryScreen from '@/features/growth/screens/DictionaryScreen';
+export default DictionaryScreen;

--- a/app/(tabs)/growth/gacha.tsx
+++ b/app/(tabs)/growth/gacha.tsx
@@ -1,0 +1,2 @@
+import GachaScreen from '@/features/growth/screens/GachaScreen';
+export default GachaScreen;

--- a/app/(tabs)/growth/index.tsx
+++ b/app/(tabs)/growth/index.tsx
@@ -1,3 +1,3 @@
 //C:\Users\fukur\task-app\app\app\(tabs)\growth\index.tsx
-import GrowthScreen from '@/features/growth/GrowScreen';
+import GrowthScreen from '@/features/growth/screens/GrowthScreen';
 export default GrowthScreen;

--- a/app/(tabs)/growth/store.tsx
+++ b/app/(tabs)/growth/store.tsx
@@ -1,0 +1,2 @@
+import StoreScreen from '@/features/growth/screens/StoreScreen';
+export default StoreScreen;

--- a/features/growth/components/DurationPickerModal.tsx
+++ b/features/growth/components/DurationPickerModal.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Modal, Pressable, View, Text, StyleSheet } from 'react-native';
+import WheelPicker from 'react-native-wheely';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  visible: boolean;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  onChangeHours: (val: number) => void;
+  onChangeMinutes: (val: number) => void;
+  onChangeSeconds: (val: number) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+const HOURS_OPTIONS = Array.from({ length: 24 }, (_, i) => `${i}`);
+const MINUTE_SECOND_OPTIONS = Array.from({ length: 60 }, (_, i) => `${i}`);
+
+export default function DurationPickerModal({
+  visible,
+  hours,
+  minutes,
+  seconds,
+  onChangeHours,
+  onChangeMinutes,
+  onChangeSeconds,
+  onConfirm,
+  onClose,
+}: Props) {
+  const { t } = useTranslation();
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <Pressable style={styles.content} onPress={(e) => e.stopPropagation()}>
+          <View style={styles.row}>
+            <WheelPicker options={HOURS_OPTIONS} selectedIndex={hours} onChange={onChangeHours} itemHeight={40} visibleRest={1} />
+            <Text style={styles.label}>{t('common.hours_label')}</Text>
+            <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={minutes} onChange={onChangeMinutes} itemHeight={40} visibleRest={1} />
+            <Text style={styles.label}>{t('common.minutes_label')}</Text>
+            <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={seconds} onChange={onChangeSeconds} itemHeight={40} visibleRest={1} />
+            <Text style={styles.label}>{t('common.seconds_label')}</Text>
+          </View>
+          <Pressable style={[styles.button, styles.confirmButton]} onPress={onConfirm}>
+            <Text style={styles.buttonText}>{t('growth.start_focus_mode')}</Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
+  content: { backgroundColor: '#fff', borderRadius: 10, padding: 20, width: '90%' },
+  row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', marginVertical: 10 },
+  label: { marginHorizontal: 5, fontSize: 16 },
+  button: { paddingVertical: 12, paddingHorizontal: 20, borderRadius: 8, alignItems: 'center', marginTop: 10 },
+  confirmButton: { backgroundColor: '#4CAF50' },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: 'bold' },
+});

--- a/features/growth/components/FocusModeOverlay.tsx
+++ b/features/growth/components/FocusModeOverlay.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Canvas, Rect } from '@shopify/react-native-skia';
+import { Ionicons } from '@expo/vector-icons';
+
+interface Props {
+  visible: boolean;
+  width: number;
+  subColor: string;
+  isDark: boolean;
+  isMuted: boolean;
+  focusModeStatus: 'idle' | 'running' | 'paused';
+  timeRemaining: number;
+  focusDurationSec: number;
+  formatTime: (sec: number) => string;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+  onToggleMute: () => void;
+}
+
+export default function FocusModeOverlay({
+  visible,
+  width,
+  subColor,
+  isDark,
+  isMuted,
+  focusModeStatus,
+  timeRemaining,
+  focusDurationSec,
+  formatTime,
+  onPause,
+  onResume,
+  onStop,
+  onToggleMute,
+}: Props) {
+  if (!visible) return null;
+  return (
+    <View style={styles.overlay}>
+      <TouchableOpacity onPress={onToggleMute} style={styles.audioButton}>
+        <Ionicons name={isMuted ? 'volume-mute' : 'musical-notes'} size={24} color="#fff" />
+      </TouchableOpacity>
+      <View style={styles.timerContainer}>
+        <Canvas style={{ width: width * 0.6, height: 10, marginBottom: 20 }}>
+          <Rect x={0} y={0} width={width * 0.6 * (timeRemaining / focusDurationSec)} height={10} color={subColor} />
+        </Canvas>
+        <Text style={styles.timerText}>{formatTime(timeRemaining)}</Text>
+        <View style={styles.controls}>
+          {focusModeStatus === 'running' ? (
+            <TouchableOpacity onPress={onPause} style={styles.controlButton}>
+              <Ionicons name="pause-circle-outline" size={50} color={subColor} />
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity onPress={onResume} style={styles.controlButton}>
+              <Ionicons name="play-circle-outline" size={50} color={subColor} />
+            </TouchableOpacity>
+          )}
+          <TouchableOpacity onPress={onStop} style={styles.controlButton}>
+            <Ionicons name="stop-circle-outline" size={50} color={isDark ? '#FF6B6B' : '#D32F2F'} />
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 10,
+  },
+  timerContainer: {
+    backgroundColor: '#fff',
+    padding: 30,
+    borderRadius: 15,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 5,
+    elevation: 10,
+  },
+  timerText: {
+    fontSize: 60,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 20,
+  },
+  controls: {
+    flexDirection: 'row',
+    gap: 20,
+  },
+  controlButton: {
+    padding: 10,
+  },
+  audioButton: {
+    position: 'absolute',
+    top: 20,
+    left: 20,
+  },
+});

--- a/features/growth/components/GrowthDisplay.tsx
+++ b/features/growth/components/GrowthDisplay.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Theme } from '../themes/types';
+
+interface Props {
+  theme: Theme | undefined;
+  progress: { totalGrowthPoints: number; currentGrowthStage: string } | undefined;
+  asset: { image: any } | undefined;
+  getProgressText: () => string;
+}
+
+export default function GrowthDisplay({ theme, progress, asset, getProgressText }: Props) {
+  const { t } = useTranslation();
+  const PLACEHOLDER_IMAGE_FALLBACK = require('@/assets/images/growth/placeholder.png');
+  const currentThemeImage = asset?.image || PLACEHOLDER_IMAGE_FALLBACK;
+
+  return (
+    <View style={styles.container}>
+      {currentThemeImage && <Image source={currentThemeImage} style={styles.image} resizeMode="contain" />}
+      <Text style={styles.info}>{t('growth.current_theme')}: {theme?.name || t('common.none')}</Text>
+      <Text style={styles.points}>{t('growth.current_points')}: {progress?.totalGrowthPoints ?? 0}</Text>
+      <Text style={styles.progress}>{getProgressText()}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20, backgroundColor: '#e8e8e8' },
+  image: { width: 200, height: 200, marginBottom: 20 },
+  info: { fontSize: 18, fontWeight: 'bold', color: '#333', marginBottom: 5 },
+  points: { fontSize: 16, color: '#555', marginBottom: 10 },
+  progress: { fontSize: 14, color: '#666', textAlign: 'center', marginBottom: 20 },
+});

--- a/features/growth/components/MenuModal.tsx
+++ b/features/growth/components/MenuModal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Modal, Pressable, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  visible: boolean;
+  onSelectDictionary: () => void;
+  onSelectGacha: () => void;
+  onSelectStore: () => void;
+  onSelectTheme: () => void;
+  onClose: () => void;
+}
+
+export default function MenuModal({ visible, onSelectDictionary, onSelectGacha, onSelectStore, onSelectTheme, onClose }: Props) {
+  const { t } = useTranslation();
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <Pressable style={styles.content} onPress={(e) => e.stopPropagation()}>
+          <TouchableOpacity style={styles.item} onPress={onSelectTheme}>
+            <Text style={styles.itemText}>{t('growth.select_theme')}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.item} onPress={onSelectDictionary}>
+            <Text style={styles.itemText}>{t('growth.gallery')}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.item} onPress={onSelectGacha}>
+            <Text style={styles.itemText}>{t('growth.gacha')}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.item} onPress={onSelectStore}>
+            <Text style={styles.itemText}>{t('growth.store')}</Text>
+          </TouchableOpacity>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
+  content: { backgroundColor: '#fff', borderRadius: 10, padding: 20, width: '90%', maxHeight: '80%' },
+  item: { paddingVertical: 10 },
+  itemText: { fontSize: 16, textAlign: 'center', paddingVertical: 5 },
+});

--- a/features/growth/components/ThemeSelectionModal.tsx
+++ b/features/growth/components/ThemeSelectionModal.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Modal, Pressable, View, Text, StyleSheet, FlatList, TouchableOpacity, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Theme } from '../themes/types';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  visible: boolean;
+  themes: Theme[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onClose: () => void;
+}
+
+export default function ThemeSelectionModal({ visible, themes, selectedId, onSelect, onClose }: Props) {
+  const { t } = useTranslation();
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <Pressable style={styles.content} onPress={(e) => e.stopPropagation()}>
+          <Text style={styles.title}>{t('growth.select_theme')}</Text>
+          <FlatList
+            data={themes}
+            keyExtractor={(item) => item.id}
+            numColumns={2}
+            renderItem={({ item }) => (
+              <TouchableOpacity
+                style={[styles.option, selectedId === item.id && styles.optionSelected, item.locked && styles.optionLocked]}
+                onPress={() => onSelect(item.id)}
+                disabled={item.locked}
+              >
+                <Image source={item.growthStages.seed.image} style={styles.optionImage} />
+                <Text style={[styles.optionName, item.locked && styles.optionNameLocked]}>{item.name}</Text>
+                {item.locked && (
+                  <View style={styles.lockedOverlay}>
+                    <Ionicons name="lock-closed" size={30} color="#FFF" />
+                  </View>
+                )}
+              </TouchableOpacity>
+            )}
+            contentContainerStyle={styles.optionsContainer}
+          />
+          <TouchableOpacity style={[styles.button, styles.closeButton]} onPress={onClose}>
+            <Text style={styles.buttonText}>{t('common.close')}</Text>
+          </TouchableOpacity>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
+  content: { backgroundColor: '#fff', borderRadius: 10, padding: 20, width: '90%', maxHeight: '80%' },
+  title: { fontSize: 20, fontWeight: 'bold', marginBottom: 20, textAlign: 'center', color: '#333' },
+  optionsContainer: { justifyContent: 'space-around', paddingBottom: 20 },
+  option: { width: '45%', aspectRatio: 1, margin: '2.5%', borderWidth: 2, borderColor: 'transparent', borderRadius: 10, alignItems: 'center', justifyContent: 'center', padding: 10, backgroundColor: '#f9f9f9', position: 'relative' },
+  optionSelected: { borderColor: '#4CAF50' },
+  optionLocked: { opacity: 0.5 },
+  optionImage: { width: '80%', height: '80%', marginBottom: 5 },
+  optionName: { fontSize: 14, fontWeight: 'bold', color: '#333', textAlign: 'center' },
+  optionNameLocked: { color: '#888' },
+  lockedOverlay: { ...StyleSheet.absoluteFillObject, backgroundColor: 'rgba(0,0,0,0.6)', borderRadius: 10, justifyContent: 'center', alignItems: 'center' },
+  button: { paddingVertical: 12, paddingHorizontal: 20, borderRadius: 8, alignItems: 'center', marginHorizontal: 20 },
+  closeButton: { marginTop: 20, backgroundColor: '#4CAF50' },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: 'bold' },
+});

--- a/features/growth/screens/DictionaryScreen.tsx
+++ b/features/growth/screens/DictionaryScreen.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Text, StyleSheet } from 'react-native';
+import { useAppTheme } from '@/hooks/ThemeContext';
+import { useTranslation } from 'react-i18next';
+
+export default function DictionaryScreen() {
+  const { colorScheme } = useAppTheme();
+  const { t } = useTranslation();
+  const isDark = colorScheme === 'dark';
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: isDark ? '#000' : '#fff' }]}>
+      <Text style={styles.text}>{t('growth.gallery')}</Text>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 20 },
+});

--- a/features/growth/screens/GachaScreen.tsx
+++ b/features/growth/screens/GachaScreen.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Text, StyleSheet } from 'react-native';
+import { useAppTheme } from '@/hooks/ThemeContext';
+import { useTranslation } from 'react-i18next';
+
+export default function GachaScreen() {
+  const { colorScheme } = useAppTheme();
+  const { t } = useTranslation();
+  const isDark = colorScheme === 'dark';
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: isDark ? '#000' : '#fff' }]}>
+      <Text style={styles.text}>{t('growth.gacha')}</Text>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 20 },
+});

--- a/features/growth/screens/StoreScreen.tsx
+++ b/features/growth/screens/StoreScreen.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Text, StyleSheet } from 'react-native';
+import { useAppTheme } from '@/hooks/ThemeContext';
+import { useTranslation } from 'react-i18next';
+
+export default function StoreScreen() {
+  const { colorScheme } = useAppTheme();
+  const { t } = useTranslation();
+  const isDark = colorScheme === 'dark';
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: isDark ? '#000' : '#fff' }]}>
+      <Text style={styles.text}>{t('growth.store')}</Text>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 20 },
+});


### PR DESCRIPTION
## Summary
- extract growth subfeatures as components
- add dictionary, gacha and store screens
- update growth route

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*
- `npx tsc --noEmit` *(fails: multiple missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68457af844d48326ba0b0d0590191dcd