### PR TITLE
Fix GrowthScreen notification trigger typing

### DIFF
--- a/features/growth/screens/GrowthScreen.tsx
+++ b/features/growth/screens/GrowthScreen.tsx
@@ -147,7 +147,7 @@ export default function GrowthScreen() {
           points: Math.ceil(focusDurationSec / 60) * GROWTH_POINTS_PER_FOCUS_MINUTE,
         }),
       },
-      trigger: { seconds: focusDurationSec },
+      trigger: { seconds: focusDurationSec, type: 'timeInterval' },
     }).then((id) => {
       notificationIdRef.current = id;
     });
@@ -200,7 +200,7 @@ export default function GrowthScreen() {
           points: Math.ceil(focusDurationSec / 60) * GROWTH_POINTS_PER_FOCUS_MINUTE,
         }),
       },
-      trigger: { seconds: timeRemaining },
+      trigger: { seconds: timeRemaining, type: 'timeInterval' },
     }).then((id) => { notificationIdRef.current = id; });
     setFocusModeStatus('running');
   }, [timeRemaining, focusDurationSec, t]);


### PR DESCRIPTION
## Summary
- fix expo-notification trigger type in `GrowthScreen`

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68457e2bb44883268271865e87d78f9c