### PR TITLE
Fix notification trigger type

### DIFF
--- a/features/growth/screens/GrowthScreen.tsx
+++ b/features/growth/screens/GrowthScreen.tsx
@@ -147,7 +147,7 @@ export default function GrowthScreen() {
           points: Math.ceil(focusDurationSec / 60) * GROWTH_POINTS_PER_FOCUS_MINUTE,
         }),
       },
-      trigger: { seconds: focusDurationSec, type: 'timeInterval' },
+      trigger: { seconds: focusDurationSec, repeats: false },
     }).then((id) => {
       notificationIdRef.current = id;
     });
@@ -200,7 +200,7 @@ export default function GrowthScreen() {
           points: Math.ceil(focusDurationSec / 60) * GROWTH_POINTS_PER_FOCUS_MINUTE,
         }),
       },
-      trigger: { seconds: timeRemaining, type: 'timeInterval' },
+      trigger: { seconds: timeRemaining, repeats: false },
     }).then((id) => { notificationIdRef.current = id; });
     setFocusModeStatus('running');
   }, [timeRemaining, focusDurationSec, t]);


### PR DESCRIPTION
## Summary
- fix expo notification trigger usage by removing invalid `type` property

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68457f03e88c8326bb6c03ca119b1b90