### PR TITLE
Hide growth subscreens from tab bar

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -99,7 +99,7 @@ function InnerTabs() {
           <Tabs.Screen name="settings/index" />
 
           {/* ✅ 非表示にしたいルートたち */}
-          {[
+          {[ 
             'settings/repeating-tasks',
             'settings/language',
             'add/index',
@@ -108,6 +108,9 @@ function InnerTabs() {
             'task-detail/[id]',
             'drafts',
             'explore',
+            'growth/gacha',
+            'growth/store',
+            'growth/dictionary',
             'index',
           ].map((name) => (
             <Tabs.Screen key={name} name={name} options={{ href: null }} />


### PR DESCRIPTION
## Summary
- add gacha, store and dictionary to the hidden tab routes

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68457f88450c832680d4aab28677ccd6