### PR TITLE
Update focus mode timer UI

### DIFF
--- a/features/growth/components/DurationPickerModal.tsx
+++ b/features/growth/components/DurationPickerModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Pressable, View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import WheelPicker from 'react-native-wheely';
 import { useTranslation } from 'react-i18next';
 
@@ -12,7 +12,6 @@ interface Props {
   onChangeMinutes: (val: number) => void;
   onChangeSeconds: (val: number) => void;
   onConfirm: () => void;
-  onClose: () => void;
 }
 
 const HOURS_OPTIONS = Array.from({ length: 24 }, (_, i) => `${i}`);
@@ -27,33 +26,28 @@ export default function DurationPickerModal({
   onChangeMinutes,
   onChangeSeconds,
   onConfirm,
-  onClose,
 }: Props) {
   const { t } = useTranslation();
+  if (!visible) return null;
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <Pressable style={styles.overlay} onPress={onClose}>
-        <Pressable style={styles.content} onPress={(e) => e.stopPropagation()}>
-          <View style={styles.row}>
-            <WheelPicker options={HOURS_OPTIONS} selectedIndex={hours} onChange={onChangeHours} itemHeight={40} visibleRest={1} />
-            <Text style={styles.label}>{t('common.hours_label')}</Text>
-            <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={minutes} onChange={onChangeMinutes} itemHeight={40} visibleRest={1} />
-            <Text style={styles.label}>{t('common.minutes_label')}</Text>
-            <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={seconds} onChange={onChangeSeconds} itemHeight={40} visibleRest={1} />
-            <Text style={styles.label}>{t('common.seconds_label')}</Text>
-          </View>
-          <Pressable style={[styles.button, styles.confirmButton]} onPress={onConfirm}>
-            <Text style={styles.buttonText}>{t('growth.start_focus_mode')}</Text>
-          </Pressable>
-        </Pressable>
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <WheelPicker options={HOURS_OPTIONS} selectedIndex={hours} onChange={onChangeHours} itemHeight={40} visibleRest={1} />
+        <Text style={styles.label}>{t('common.hours_label')}</Text>
+        <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={minutes} onChange={onChangeMinutes} itemHeight={40} visibleRest={1} />
+        <Text style={styles.label}>{t('common.minutes_label')}</Text>
+        <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={seconds} onChange={onChangeSeconds} itemHeight={40} visibleRest={1} />
+        <Text style={styles.label}>{t('common.seconds_label')}</Text>
+      </View>
+      <Pressable style={[styles.button, styles.confirmButton]} onPress={onConfirm}>
+        <Text style={styles.buttonText}>{t('growth.start_focus_mode')}</Text>
       </Pressable>
-    </Modal>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
-  content: { backgroundColor: '#fff', borderRadius: 10, padding: 20, width: '90%' },
+  container: { padding: 20, backgroundColor: '#fff', borderRadius: 10 },
   row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', marginVertical: 10 },
   label: { marginHorizontal: 5, fontSize: 16 },
   button: { paddingVertical: 12, paddingHorizontal: 20, borderRadius: 8, alignItems: 'center', marginTop: 10 },

--- a/features/growth/components/FocusModeOverlay.tsx
+++ b/features/growth/components/FocusModeOverlay.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { Canvas, Rect } from '@shopify/react-native-skia';
+import Svg, { Circle } from 'react-native-svg';
 import { Ionicons } from '@expo/vector-icons';
 
 interface Props {
@@ -35,15 +35,28 @@ export default function FocusModeOverlay({
   onToggleMute,
 }: Props) {
   if (!visible) return null;
+  const size = width * 0.6;
+  const radius = size / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = timeRemaining / focusDurationSec;
   return (
     <View style={styles.overlay}>
       <TouchableOpacity onPress={onToggleMute} style={styles.audioButton}>
         <Ionicons name={isMuted ? 'volume-mute' : 'musical-notes'} size={24} color="#fff" />
       </TouchableOpacity>
       <View style={styles.timerContainer}>
-        <Canvas style={{ width: width * 0.6, height: 10, marginBottom: 20 }}>
-          <Rect x={0} y={0} width={width * 0.6 * (timeRemaining / focusDurationSec)} height={10} color={subColor} />
-        </Canvas>
+        <Svg width={size} height={size} style={styles.progressCircle}>
+          <Circle
+            cx={radius}
+            cy={radius}
+            r={radius}
+            stroke="#fff"
+            strokeWidth={10}
+            fill="none"
+            strokeDasharray={`${circumference}`}
+            strokeDashoffset={circumference * (1 - progress)}
+          />
+        </Svg>
         <Text style={styles.timerText}>{formatTime(timeRemaining)}</Text>
         <View style={styles.controls}>
           {focusModeStatus === 'running' ? (
@@ -73,20 +86,13 @@ const styles = StyleSheet.create({
     zIndex: 10,
   },
   timerContainer: {
-    backgroundColor: '#fff',
-    padding: 30,
-    borderRadius: 15,
     alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 5,
-    elevation: 10,
+    padding: 30,
   },
   timerText: {
     fontSize: 60,
     fontWeight: 'bold',
-    color: '#333',
+    color: '#fff',
     marginBottom: 20,
   },
   controls: {
@@ -100,5 +106,8 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 20,
     left: 20,
+  },
+  progressCircle: {
+    marginBottom: 20,
   },
 });

--- a/features/growth/screens/GrowthScreen.tsx
+++ b/features/growth/screens/GrowthScreen.tsx
@@ -1,7 +1,7 @@
 // features/growth/GrowthScreen.tsx
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Animated as RNAnimated, Vibration, Alert, useWindowDimensions } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Vibration, Alert, useWindowDimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAppTheme } from '@/hooks/ThemeContext';
 import { useTranslation } from 'react-i18next';
@@ -51,7 +51,6 @@ export default function GrowthScreen() {
   const [tempMinutes, setTempMinutes] = useState(25);
   const [tempSeconds, setTempSeconds] = useState(0);
   const [isMuted, setMuted] = useState(false);
-  const fadeAnim = useRef(new RNAnimated.Value(1)).current;
   
   // ここを修正: NodeJS.Timeoutの代わりに ReturnType<typeof setInterval> を使用
   const timerIntervalRef = useRef<number | null>(null);
@@ -124,13 +123,6 @@ export default function GrowthScreen() {
     };
   }, [focusModeStatus, focusDurationSec, selectedThemeId, addGrowthPoints, t]);
 
-  useEffect(() => {
-    RNAnimated.timing(fadeAnim, {
-      toValue: isFocusModeActive ? 0 : 1,
-      duration: 300,
-      useNativeDriver: true,
-    }).start();
-  }, [isFocusModeActive, fadeAnim]);
 
 
   const startFocusMode = useCallback(() => {
@@ -324,25 +316,28 @@ export default function GrowthScreen() {
         onChangeMinutes={setTempMinutes}
         onChangeSeconds={setTempSeconds}
         onConfirm={confirmDurationPicker}
-        onClose={() => setDurationPickerVisible(false)}
       />
 
-      <RNAnimated.View style={[styles.bottomActions, { opacity: fadeAnim }]}>
+      <View style={styles.bottomActions}>
         <TouchableOpacity onPress={toggleMute} style={styles.bottomActionButton}>
           <Ionicons name={isMuted ? 'volume-mute' : 'musical-notes'} size={24} color={isDark ? '#fff' : '#000'} />
         </TouchableOpacity>
         <TouchableOpacity
-          onPress={isFocusModeActive ? stopFocusMode : showDurationPicker}
+          onPress={showDurationPicker}
           style={[styles.focusModeToggleButton, { backgroundColor: subColor }]}
         >
-          <Text style={styles.focusModeToggleText}>
-            {isFocusModeActive ? t('growth.focus_mode_button_stop') : t('growth.focus_mode_button_start')}
-          </Text>
+          <Text style={styles.focusModeToggleText}>{t('growth.start_focus_mode')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={stopFocusMode}
+          style={[styles.focusModeToggleButton, { backgroundColor: subColor }]}
+        >
+          <Text style={styles.focusModeToggleText}>{t('growth.focus_mode_button_stop')}</Text>
         </TouchableOpacity>
         <TouchableOpacity onPress={() => setMenuVisible(true)} style={styles.bottomActionButton}>
           <Ionicons name="menu" size={24} color={isDark ? '#fff' : '#000'} />
         </TouchableOpacity>
-      </RNAnimated.View>
+      </View>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary
- show duration picker inline instead of modal
- use white circular progress display for focus mode
- keep bottom tab visible and provide separate start and stop buttons

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684581de900883268a23352155642551