### PR TITLE
Update calendar font

### DIFF
--- a/features/calendar/components/SkiaCalendar.tsx
+++ b/features/calendar/components/SkiaCalendar.tsx
@@ -11,7 +11,7 @@ import { runOnJS } from 'react-native-reanimated';
 import type { Task } from '@/features/tasks/types';
 import type { EventLayout } from '../utils';
 
-const FONT_PATH_BOLD = require('@/assets/fonts/NotoSansJP-Bold.ttf');
+const FONT_PATH_MEDIUM = require('@/assets/fonts/NotoSansJP-Medium.ttf');
 const FONT_PATH_REGULAR = require('@/assets/fonts/NotoSansJP-Regular.ttf');
 // カレンダー表示用のパディング量（大表示時は0）
 // パディングなしで全幅表示
@@ -62,7 +62,7 @@ export default function SkiaCalendar({
   const cellWidth = calendarWidth / 7;
   const cellHeight = showTaskTitles ? cellWidth * 1.5 : cellWidth; // 大表示時は縦長に
 
-  const font = useFont(FONT_PATH_BOLD, 14);
+  const font = useFont(FONT_PATH_MEDIUM, 14);
   const eventFont = useFont(FONT_PATH_REGULAR, 10);
   const skiaImage = backgroundImage ? useImage(backgroundImage) : null;
 


### PR DESCRIPTION
## Summary
- switch SkiaCalendar weekday/day font to NotoSansJP-Medium

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684587eab85883269444c249f0c9e736