### PR TITLE
Fix infinite render loop in CalendarScreen

### DIFF
--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -99,11 +99,16 @@ export default function CalendarPage() {
   >({});
   const eventLayout = useMemo(() => {
     const key = displayMonth.format('YYYY-MM');
-    if (eventCache[key]) return eventCache[key];
-    const layout = processMultiDayEvents(allMonthEvents, displayMonth);
-    setEventCache(prev => ({ ...prev, [key]: layout }));
-    return layout;
-  }, [allMonthEvents, displayMonth]);
+    return eventCache[key] || processMultiDayEvents(allMonthEvents, displayMonth);
+  }, [eventCache, allMonthEvents, displayMonth]);
+
+  useEffect(() => {
+    const key = displayMonth.format('YYYY-MM');
+    if (!eventCache[key]) {
+      const layout = processMultiDayEvents(allMonthEvents, displayMonth);
+      setEventCache(prev => ({ ...prev, [key]: layout }));
+    }
+  }, [eventCache, allMonthEvents, displayMonth]);
 
   useEffect(() => {
     const prev = displayMonth.subtract(1, 'month');


### PR DESCRIPTION
## Summary
- fix event layout caching to avoid setState during render in CalendarScreen

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Missing script `lint`)*

------
https://chatgpt.com/codex/tasks/task_e_68458995880083268366c62c422f216a