### PR TITLE
Growth screen timer improvements

### DIFF
--- a/features/growth/components/DurationPickerModal.tsx
+++ b/features/growth/components/DurationPickerModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { View, Text, StyleSheet, Pressable, Modal } from 'react-native';
 import WheelPicker from 'react-native-wheely';
 import { useTranslation } from 'react-i18next';
 
@@ -12,6 +12,7 @@ interface Props {
   onChangeMinutes: (val: number) => void;
   onChangeSeconds: (val: number) => void;
   onConfirm: () => void;
+  onClose: () => void;
 }
 
 const HOURS_OPTIONS = Array.from({ length: 24 }, (_, i) => `${i}`);
@@ -26,27 +27,32 @@ export default function DurationPickerModal({
   onChangeMinutes,
   onChangeSeconds,
   onConfirm,
+  onClose,
 }: Props) {
   const { t } = useTranslation();
-  if (!visible) return null;
   return (
-    <View style={styles.container}>
-      <View style={styles.row}>
-        <WheelPicker options={HOURS_OPTIONS} selectedIndex={hours} onChange={onChangeHours} itemHeight={40} visibleRest={1} />
-        <Text style={styles.label}>{t('common.hours_label')}</Text>
-        <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={minutes} onChange={onChangeMinutes} itemHeight={40} visibleRest={1} />
-        <Text style={styles.label}>{t('common.minutes_label')}</Text>
-        <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={seconds} onChange={onChangeSeconds} itemHeight={40} visibleRest={1} />
-        <Text style={styles.label}>{t('common.seconds_label')}</Text>
-      </View>
-      <Pressable style={styles.button} onPress={onConfirm}>
-        <Text style={styles.buttonText}>{t('growth.start_focus_mode')}</Text>
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <Pressable style={styles.container} onPress={(e) => e.stopPropagation()}>
+          <View style={styles.row}>
+            <WheelPicker options={HOURS_OPTIONS} selectedIndex={hours} onChange={onChangeHours} itemHeight={40} visibleRest={1} />
+            <Text style={styles.label}>{t('common.hours_label')}</Text>
+            <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={minutes} onChange={onChangeMinutes} itemHeight={40} visibleRest={1} />
+            <Text style={styles.label}>{t('common.minutes_label')}</Text>
+            <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={seconds} onChange={onChangeSeconds} itemHeight={40} visibleRest={1} />
+            <Text style={styles.label}>{t('common.seconds_label')}</Text>
+          </View>
+          <Pressable style={styles.button} onPress={onConfirm}>
+            <Text style={styles.buttonText}>{t('growth.start_focus_mode')}</Text>
+          </Pressable>
+        </Pressable>
       </Pressable>
-    </View>
+    </Modal>
   );
 }
 
 const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
   container: { padding: 20, backgroundColor: '#fff', borderRadius: 10 },
   row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', marginVertical: 10 },
   label: { marginHorizontal: 5, fontSize: 16 },

--- a/features/growth/components/FocusModeOverlay.tsx
+++ b/features/growth/components/FocusModeOverlay.tsx
@@ -55,6 +55,9 @@ export default function FocusModeOverlay({
             fill="none"
             strokeDasharray={`${circumference}`}
             strokeDashoffset={circumference * (1 - progress)}
+            rotation={-90}
+            originX={radius}
+            originY={radius}
           />
         </Svg>
         <Text style={styles.timerText}>{formatTime(timeRemaining)}</Text>
@@ -80,7 +83,7 @@ export default function FocusModeOverlay({
 const styles = StyleSheet.create({
   overlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.5)',
+    backgroundColor: 'transparent',
     justifyContent: 'center',
     alignItems: 'center',
     zIndex: 10,

--- a/features/growth/screens/GrowthScreen.tsx
+++ b/features/growth/screens/GrowthScreen.tsx
@@ -9,7 +9,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useGrowth } from '../hooks/useGrowth';
 import { GROWTH_THRESHOLDS, GROWTH_POINTS_PER_FOCUS_MINUTE } from '../themes'; // GROWTH_POINTS_PER_FOCUS_MINUTE を追加
 import { Theme, GrowthStage } from '../themes/types'; // types.tsからThemeとGrowthStageを直接インポート
-import { useFocusEffect, useRouter } from 'expo-router';
+import { useFocusEffect, useRouter, useLocalSearchParams } from 'expo-router';
 import * as Notifications from 'expo-notifications';
 import GrowthDisplay from '../components/GrowthDisplay';
 import ThemeSelectionModal from '../components/ThemeSelectionModal';
@@ -26,6 +26,8 @@ export default function GrowthScreen() {
   const { t } = useTranslation();
   const { width } = useWindowDimensions();
   const router = useRouter();
+  const { view } = useLocalSearchParams<{ view?: string }>();
+  const isViewMode = view === 'true';
 
   const {
     loading,
@@ -321,6 +323,7 @@ export default function GrowthScreen() {
         onChangeMinutes={setTempMinutes}
         onChangeSeconds={setTempSeconds}
         onConfirm={confirmDurationPicker}
+        onClose={() => setDurationPickerVisible(false)}
       />
 
       <View style={[styles.bottomActions, { backgroundColor: tabBackgroundColor }]}>
@@ -330,10 +333,16 @@ export default function GrowthScreen() {
         <TouchableOpacity onPress={showDurationPicker} style={styles.focusModeToggleButton}>
           <Text style={[styles.focusModeToggleText, { color: subColor }]}>{t('growth.start_focus_mode')}</Text>
         </TouchableOpacity>
-        <TouchableOpacity onPress={stopFocusMode} style={styles.focusModeToggleButton}>
-          <Text style={[styles.focusModeToggleText, { color: subColor }]}>{t('growth.focus_mode_button_stop')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity onPress={() => setMenuVisible(true)} style={styles.bottomActionButton}>
+        {!isViewMode && (
+          <TouchableOpacity onPress={stopFocusMode} style={styles.focusModeToggleButton}>
+            <Text style={[styles.focusModeToggleText, { color: subColor }]}>{t('growth.focus_mode_button_stop')}</Text>
+          </TouchableOpacity>
+        )}
+        <TouchableOpacity
+          onPress={() => setMenuVisible(true)}
+          style={styles.bottomActionButton}
+          disabled={focusModeStatus === 'running' || focusModeStatus === 'paused'}
+        >
           <Ionicons name="menu" size={24} color={tabIconColor} />
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
## Summary
- rotate progress circle so it counts down clockwise from the top
- remove screen dimming during focus mode
- show duration picker as overlay modal
- disable menu button during timer
- hide stop button when viewing only

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458c0630308326810862a3063435bf