### PR TITLE
Adjust full calendar height

### DIFF
--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -30,6 +30,7 @@ const SUNDAY_COLOR = '#FF6666';
 const SATURDAY_COLOR = '#66B2FF';
 // 曜日欄の高さに合わせて短くする
 const HEADER_HEIGHT = 24;
+const FULL_CELL_HEIGHT_FACTOR = 1.9;
 
 export default function CalendarPage() {
   const { t } = useTranslation();
@@ -58,7 +59,7 @@ export default function CalendarPage() {
     const PADDING = 0;
     const calendarWidth = width - PADDING * 2;
     const cellWidth = calendarWidth / 7;
-    const cellHeight = viewType === 'full' ? cellWidth * 1.5 : cellWidth;
+    const cellHeight = viewType === 'full' ? cellWidth * FULL_CELL_HEIGHT_FACTOR : cellWidth;
 
     const firstDayOfMonth = displayMonth.startOf('month');
     const daysInMonth = displayMonth.daysInMonth();

--- a/features/calendar/components/SkiaCalendar.tsx
+++ b/features/calendar/components/SkiaCalendar.tsx
@@ -19,6 +19,7 @@ const FONT_PATH_REGULAR = require('@/assets/fonts/NotoSansJP-Regular.ttf');
 const PADDING = 0;
 // 曜日欄の高さをさらにコンパクトに
 const HEADER_HEIGHT = 24;
+const FULL_CELL_HEIGHT_FACTOR = 1.9;
 const TASK_BAR_HEIGHT = 5;
 const TASK_BAR_MARGIN = 3;
 const EVENT_BAR_HEIGHT = 20;
@@ -68,7 +69,7 @@ export default function SkiaCalendar({
   const { width } = useWindowDimensions();
   const calendarWidth = width - PADDING * 2;
   const cellWidth = calendarWidth / 7;
-  const cellHeight = showTaskTitles ? cellWidth * 1.5 : cellWidth; // 大表示時は縦長に
+  const cellHeight = showTaskTitles ? cellWidth * FULL_CELL_HEIGHT_FACTOR : cellWidth; // 大表示時は縦長に
 
   const font = useFont(FONT_PATH_MEDIUM, CALENDAR_FONT_SIZES[fontSizeKey]);
   const eventFont = useFont(FONT_PATH_REGULAR, 10);


### PR DESCRIPTION
## Summary
- enlarge full calendar cells so the large view fills more vertical space

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68458d6277508326a3d5328978fc9474