### PR TITLE
fix: update tab sync effect

### DIFF
--- a/features/tasks/hooks/useTasksScreenLogic.ts
+++ b/features/tasks/hooks/useTasksScreenLogic.ts
@@ -133,7 +133,9 @@ export const useTasksScreenLogic = () => {
 
   // ★ フォルダタブリストの変更（例：未完了/完了の切替）時に、ページャーの位置を同期させる
   useEffect(() => {
-    const targetIndex = folderTabs.findIndex(ft => ft.name === selectedFolderTabName);
+    const targetIndex = folderTabs.findIndex(
+      (ft) => ft.name === selectedFolderTabName
+    );
     const newIndex = targetIndex !== -1 ? targetIndex : 0;
 
     if (selectedTabIndex !== newIndex) {
@@ -142,7 +144,7 @@ export const useTasksScreenLogic = () => {
       pagerRef.current?.setPageWithoutAnimation(newIndex);
       pageScrollPosition.value = newIndex;
     }
-  }, [folderTabs]);
+  }, [folderTabs, selectedFolderTabName]);
 
 
   const scrollFolderTabsToCenter = useCallback((pageIndex: number) => {


### PR DESCRIPTION
## Summary
- synchronize tab index when selected folder changes by adding dependency

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845a8fad280832692145c3dbbe3d45c