### PR TITLE
Configure Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,16 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
 2. Start the app
 
    ```bash
-    npx expo start
+   npx expo start
    ```
+
+### Tests
+
+Jest を使ったテストを実行するには次のコマンドを利用します。
+
+```bash
+npm test
+```
 
 In the output, you'll find options to open the app in a
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'jest-expo',
+  testMatch: ['<rootDir>/__tests__/**/*.test.tsx'],
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)'
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -7,19 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "test": "jest --watchAll"
-  },
-  "jest": {
-    "preset": "jest-expo",
-    "testMatch": [
-      "<rootDir>/__tests__/**/*.test.tsx"
-    ],
-    "setupFiles": [
-      "<rootDir>/jest.setup.js"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)"
-    ]
+    "test": "jest --config jest.config.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",


### PR DESCRIPTION
## Summary
- move Jest settings to jest.config.js
- update test script to use config file
- add documentation for running tests

## Testing
- `npm test --silent` *(fails: jest: not found)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845b347add88326a7e02e651a11a917