### PR TITLE
Fix potential state update loop in CalendarScreen

### DIFF
--- a/features/calendar/CalendarScreen.tsx
+++ b/features/calendar/CalendarScreen.tsx
@@ -103,13 +103,14 @@ export default function CalendarPage() {
     return eventCache[key] || processMultiDayEvents(allMonthEvents, displayMonth);
   }, [eventCache, allMonthEvents, displayMonth]);
 
+  // キャッシュに存在しない月のレイアウトのみを生成
   useEffect(() => {
     const key = displayMonth.format('YYYY-MM');
     if (!eventCache[key]) {
       const layout = processMultiDayEvents(allMonthEvents, displayMonth);
       setEventCache(prev => ({ ...prev, [key]: layout }));
     }
-  }, [eventCache, allMonthEvents, displayMonth]);
+  }, [allMonthEvents, displayMonth]);
 
   useEffect(() => {
     const prev = displayMonth.subtract(1, 'month');


### PR DESCRIPTION
## Summary
- avoid re-running `useEffect` when only the event cache changed

## Testing
- `npm test --silent` *(fails: `jest: not found`)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6845b3d557208326b85dff732fea4a30