### PR TITLE
Focus mode overlay adjustments

### DIFF
--- a/features/growth/components/DurationPickerModal.tsx
+++ b/features/growth/components/DurationPickerModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, Pressable, Modal } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import WheelPicker from 'react-native-wheely';
 import { useTranslation } from 'react-i18next';
 
@@ -13,6 +13,7 @@ interface Props {
   onChangeSeconds: (val: number) => void;
   onConfirm: () => void;
   onClose: () => void;
+  textColor: string;
 }
 
 const HOURS_OPTIONS = Array.from({ length: 24 }, (_, i) => `${i}`);
@@ -28,34 +29,55 @@ export default function DurationPickerModal({
   onChangeSeconds,
   onConfirm,
   onClose,
+  textColor,
 }: Props) {
   const { t } = useTranslation();
+  if (!visible) return null;
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <Pressable style={styles.overlay} onPress={onClose}>
-        <Pressable style={styles.container} onPress={(e) => e.stopPropagation()}>
-          <View style={styles.row}>
-            <WheelPicker options={HOURS_OPTIONS} selectedIndex={hours} onChange={onChangeHours} itemHeight={40} visibleRest={1} />
-            <Text style={styles.label}>{t('common.hours_label')}</Text>
-            <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={minutes} onChange={onChangeMinutes} itemHeight={40} visibleRest={1} />
-            <Text style={styles.label}>{t('common.minutes_label')}</Text>
-            <WheelPicker options={MINUTE_SECOND_OPTIONS} selectedIndex={seconds} onChange={onChangeSeconds} itemHeight={40} visibleRest={1} />
-            <Text style={styles.label}>{t('common.seconds_label')}</Text>
-          </View>
-          <Pressable style={styles.button} onPress={onConfirm}>
-            <Text style={styles.buttonText}>{t('growth.start_focus_mode')}</Text>
-          </Pressable>
+    <Pressable style={styles.overlay} onPress={onClose}>
+      <Pressable style={styles.container} onPress={(e) => e.stopPropagation()}>
+        <View style={styles.row}>
+          <WheelPicker
+            options={HOURS_OPTIONS}
+            selectedIndex={hours}
+            onChange={onChangeHours}
+            itemHeight={40}
+            visibleRest={1}
+            itemTextStyle={{ color: textColor }}
+          />
+          <Text style={[styles.label, { color: textColor }]}>{t('common.hours_label')}</Text>
+          <WheelPicker
+            options={MINUTE_SECOND_OPTIONS}
+            selectedIndex={minutes}
+            onChange={onChangeMinutes}
+            itemHeight={40}
+            visibleRest={1}
+            itemTextStyle={{ color: textColor }}
+          />
+          <Text style={[styles.label, { color: textColor }]}>{t('common.minutes_label')}</Text>
+          <WheelPicker
+            options={MINUTE_SECOND_OPTIONS}
+            selectedIndex={seconds}
+            onChange={onChangeSeconds}
+            itemHeight={40}
+            visibleRest={1}
+            itemTextStyle={{ color: textColor }}
+          />
+          <Text style={[styles.label, { color: textColor }]}>{t('common.seconds_label')}</Text>
+        </View>
+        <Pressable style={styles.button} onPress={onConfirm}>
+          <Text style={[styles.buttonText, { color: textColor }]}>{t('growth.start_focus_mode')}</Text>
         </Pressable>
       </Pressable>
-    </Modal>
+    </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
-  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
-  container: { padding: 20, backgroundColor: '#fff', borderRadius: 10 },
+  overlay: { ...StyleSheet.absoluteFillObject, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' },
+  container: { padding: 0, backgroundColor: 'transparent' },
   row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', marginVertical: 10 },
   label: { marginHorizontal: 5, fontSize: 16 },
   button: { paddingVertical: 12, paddingHorizontal: 20, alignItems: 'center', marginTop: 10 },
-  buttonText: { color: '#4CAF50', fontSize: 16, fontWeight: 'bold' },
+  buttonText: { fontSize: 16, fontWeight: 'bold' },
 });

--- a/features/growth/components/FocusModeOverlay.tsx
+++ b/features/growth/components/FocusModeOverlay.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Svg, { Circle } from 'react-native-svg';
 import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
 
 interface Props {
   visible: boolean;
@@ -36,6 +37,7 @@ export default function FocusModeOverlay({
   onToggleMute,
 }: Props) {
   if (!visible) return null;
+  const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const size = width * 0.6;
   const strokeWidth = 10;
@@ -78,15 +80,15 @@ export default function FocusModeOverlay({
         <View style={styles.controls}>
           {focusModeStatus === 'running' ? (
             <TouchableOpacity onPress={onPause} style={styles.controlButton}>
-              <Ionicons name="pause-circle-outline" size={50} color={subColor} />
+              <Text style={styles.controlText}>{t('growth.pause')}</Text>
             </TouchableOpacity>
           ) : (
             <TouchableOpacity onPress={onResume} style={styles.controlButton}>
-              <Ionicons name="play-circle-outline" size={50} color={subColor} />
+              <Text style={styles.controlText}>{t('growth.resume')}</Text>
             </TouchableOpacity>
           )}
           <TouchableOpacity onPress={onStop} style={styles.controlButton}>
-            <Ionicons name="stop-circle-outline" size={50} color={isDark ? '#FF6B6B' : '#D32F2F'} />
+            <Text style={styles.controlText}>{t('growth.end')}</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -118,6 +120,11 @@ const styles = StyleSheet.create({
   },
   controlButton: {
     padding: 10,
+  },
+  controlText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
   },
   audioButton: {
     position: 'absolute',

--- a/features/growth/screens/GrowthScreen.tsx
+++ b/features/growth/screens/GrowthScreen.tsx
@@ -209,27 +209,19 @@ export default function GrowthScreen() {
   }, []);
 
   const stopFocusMode = useCallback(() => {
-    Alert.alert( // Alertが正しくインポートされたので使用可能
-      t('growth.stop_focus_mode_title'),
-      t('growth.stop_focus_mode_message'),
-      [
-        { text: t('common.cancel'), style: 'cancel' },
-        { text: t('common.ok'), onPress: () => {
-          if (timerIntervalRef.current) {
-            clearInterval(timerIntervalRef.current);
-            timerIntervalRef.current = null;
-          }
-          if (notificationIdRef.current) {
-            Notifications.cancelScheduledNotificationAsync(notificationIdRef.current).catch(() => {});
-            notificationIdRef.current = null;
-          }
-          setFocusModeStatus('idle');
-          setFocusModeActive(false);
-          setTimeRemaining(focusDurationSec); // Reset timer
-        }}
-      ]
-    );
-  }, [focusDurationSec, t]);
+    if (timerIntervalRef.current) {
+      clearInterval(timerIntervalRef.current);
+      timerIntervalRef.current = null;
+    }
+    if (notificationIdRef.current) {
+      Notifications.cancelScheduledNotificationAsync(notificationIdRef.current).catch(() => {});
+      notificationIdRef.current = null;
+    }
+    setFocusModeStatus('idle');
+    setFocusModeActive(false);
+    setTimeRemaining(focusDurationSec);
+    showDurationPicker();
+  }, [focusDurationSec, showDurationPicker]);
 
   const handleFocusModeCompletion = useCallback(() => {
     if (notificationIdRef.current) {
@@ -324,19 +316,23 @@ export default function GrowthScreen() {
         onChangeSeconds={setTempSeconds}
         onConfirm={confirmDurationPicker}
         onClose={() => setDurationPickerVisible(false)}
+        textColor="#fff"
       />
 
       <View style={[styles.bottomActions, { backgroundColor: tabBackgroundColor }]}>
         <TouchableOpacity onPress={toggleMute} style={styles.bottomActionButton}>
           <Ionicons name={isMuted ? 'volume-mute' : 'musical-notes'} size={24} color={tabIconColor} />
         </TouchableOpacity>
-        <TouchableOpacity onPress={showDurationPicker} style={styles.focusModeToggleButton}>
-          <Text style={[styles.focusModeToggleText, { color: subColor }]}>{t('growth.start_focus_mode')}</Text>
-        </TouchableOpacity>
-        {!isViewMode && (
-          <TouchableOpacity onPress={stopFocusMode} style={styles.focusModeToggleButton}>
-            <Text style={[styles.focusModeToggleText, { color: subColor }]}>{t('growth.focus_mode_button_stop')}</Text>
+        {focusModeStatus === 'idle' ? (
+          <TouchableOpacity onPress={showDurationPicker} style={styles.focusModeToggleButton}>
+            <Text style={[styles.focusModeToggleText, { color: subColor }]}>{t('growth.start_focus_mode')}</Text>
           </TouchableOpacity>
+        ) : (
+          !isViewMode && (
+            <TouchableOpacity onPress={stopFocusMode} style={styles.focusModeToggleButton}>
+              <Text style={[styles.focusModeToggleText, { color: subColor }]}>{t('growth.focus_mode_button_stop')}</Text>
+            </TouchableOpacity>
+          )
         )}
         <TouchableOpacity
           onPress={() => setMenuVisible(true)}

--- a/locales/en.json
+++ b/locales/en.json
@@ -391,6 +391,9 @@
     "description": "Your tree grows as you complete tasks",
     "completed": "Completed tasks: {{count}}",
     "focus_mode_button_start": "Focus Mode",
-    "focus_mode_button_stop": "Stop Focus Mode"
+    "focus_mode_button_stop": "Stop Focus Mode",
+    "pause": "Pause",
+    "resume": "Resume",
+    "end": "End"
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -412,6 +412,9 @@
     "focus_mode_completed_message": "{{minutes}}分の集中モードが完了し、{{points}}ポイント獲得しました！",
     "focus_mode_button_start": "集中モード",
     "focus_mode_button_stop": "集中モードを終了",
+    "pause": "一時停止",
+    "resume": "再開",
+    "end": "終了",
     "store": "ストア",
     "gacha": "ガチャ",
     "gallery": "図鑑"

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -391,6 +391,9 @@
     "description": "작업을 완료하면 나무가 자라납니다",
     "completed": "완료한 작업 수: {{count}}",
     "focus_mode_button_start": "집중 모드",
-    "focus_mode_button_stop": "집중 모드 종료"
+    "focus_mode_button_stop": "집중 모드 종료",
+    "pause": "일시 중지",
+    "resume": "재개",
+    "end": "종료"
   }
 }


### PR DESCRIPTION
## Summary
- refine `DurationPickerModal` to behave as overlay
- update `FocusModeOverlay` buttons to text
- update `GrowthScreen` to toggle start/stop controls and show picker on stop
- add translations for pause/resume/end

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845babf679c832699aaee4b54cc2f96