### PR TITLE
Fix React 19 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-native-pager-view": "6.7.1",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.11.1",
+    "react-native-screens": "^4.11.1-nightly-20250607-d017e7ba9",
     "react-native-svg": "15.11.2",
     "react-native-tab-view": "^4.1.1",
     "react-native-toast-message": "^2.3.0",


### PR DESCRIPTION
## Summary
- bump `react-native-screens` to the nightly release for React 19 compatibility

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Missing script `lint`)*

------
https://chatgpt.com/codex/tasks/task_e_6845bd994c4c8326908e998de8a300a1