### PR TITLE
Fix focus mode picker reopening

### DIFF
--- a/features/growth/screens/GrowthScreen.tsx
+++ b/features/growth/screens/GrowthScreen.tsx
@@ -220,8 +220,7 @@ export default function GrowthScreen() {
     setFocusModeStatus('idle');
     setFocusModeActive(false);
     setTimeRemaining(focusDurationSec);
-    showDurationPicker();
-  }, [focusDurationSec, showDurationPicker]);
+  }, [focusDurationSec]);
 
   const handleFocusModeCompletion = useCallback(() => {
     if (notificationIdRef.current) {


### PR DESCRIPTION
## Summary
- avoid reopening the duration picker when ending focus mode

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845f059d4e08326a5ecc4e6fd03a21c