### PR TITLE
Update focus mode workflow

### DIFF
--- a/features/growth/components/FocusModeOverlay.tsx
+++ b/features/growth/components/FocusModeOverlay.tsx
@@ -15,6 +15,7 @@ interface Props {
   timeRemaining: number;
   focusDurationSec: number;
   formatTime: (sec: number) => string;
+  onStart: () => void;
   onPause: () => void;
   onResume: () => void;
   onStop: () => void;
@@ -31,6 +32,7 @@ export default function FocusModeOverlay({
   timeRemaining,
   focusDurationSec,
   formatTime,
+  onStart,
   onPause,
   onResume,
   onStop,
@@ -82,9 +84,13 @@ export default function FocusModeOverlay({
             <TouchableOpacity onPress={onPause} style={styles.controlButton}>
               <Text style={styles.controlText}>{t('growth.pause')}</Text>
             </TouchableOpacity>
-          ) : (
+          ) : focusModeStatus === 'paused' ? (
             <TouchableOpacity onPress={onResume} style={styles.controlButton}>
               <Text style={styles.controlText}>{t('growth.resume')}</Text>
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity onPress={onStart} style={styles.controlButton}>
+              <Text style={styles.controlText}>{t('growth.start_focus_mode')}</Text>
             </TouchableOpacity>
           )}
           <TouchableOpacity onPress={onStop} style={styles.controlButton}>

--- a/features/growth/screens/GrowthScreen.tsx
+++ b/features/growth/screens/GrowthScreen.tsx
@@ -170,8 +170,9 @@ export default function GrowthScreen() {
     setFocusDurationSec(totalSec);
     setTimeRemaining(totalSec);
     setDurationPickerVisible(false);
-    startFocusMode();
-  }, [tempHours, tempMinutes, tempSeconds, startFocusMode]);
+    setFocusModeActive(true);
+    setFocusModeStatus('idle');
+  }, [tempHours, tempMinutes, tempSeconds]);
 
   const pauseFocusMode = useCallback(() => {
     if (timerIntervalRef.current !== null) {
@@ -282,6 +283,7 @@ export default function GrowthScreen() {
         timeRemaining={timeRemaining}
         focusDurationSec={focusDurationSec}
         formatTime={formatTime}
+        onStart={startFocusMode}
         onPause={pauseFocusMode}
         onResume={resumeFocusMode}
         onStop={stopFocusMode}

--- a/locales/en.json
+++ b/locales/en.json
@@ -390,6 +390,7 @@
     "title": "Growth",
     "description": "Your tree grows as you complete tasks",
     "completed": "Completed tasks: {{count}}",
+    "start_focus_mode": "Start Focus Mode",
     "focus_mode_button_start": "Focus Mode",
     "focus_mode_button_stop": "Stop Focus Mode",
     "pause": "Pause",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -390,6 +390,7 @@
     "title": "성장",
     "description": "작업을 완료하면 나무가 자라납니다",
     "completed": "완료한 작업 수: {{count}}",
+    "start_focus_mode": "집중 모드 시작",
     "focus_mode_button_start": "집중 모드",
     "focus_mode_button_stop": "집중 모드 종료",
     "pause": "일시 중지",


### PR DESCRIPTION
## Summary
- start focus mode from overlay
- show start/pause/resume/end controls depending on state
- add translation key for `start_focus_mode`

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6845f3d03d60832698788fac63cef2ac