### PR TITLE
Fix expo-router bundling issue

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,7 @@ module.exports = function (api) {
           '@': './',
         },
       }],
+      'expo-router/babel',
       'react-native-reanimated/plugin',
     ],
   };


### PR DESCRIPTION
## Summary
- add `expo-router/babel` plugin to babel config

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Missing script 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_68457c62923c8326a73313213a236887