### PR TITLE
Fix expo-router entry resolution on Android

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,7 @@ module.exports = function (api) {
           '@': './',
         },
       }],
+      'expo-router/babel',
       'react-native-reanimated/plugin',
     ],
   };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import 'expo-router/entry';
+import { AppRegistry } from 'react-native';
+import GoogleSyncTask from './background/GoogleSyncTask';
+
+AppRegistry.registerHeadlessTask('GoogleCalendarSync', () => GoogleSyncTask);


### PR DESCRIPTION
## Summary
- add missing `index.js` entry file for Metro bundler

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Missing script 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_68457c62923c8326a73313213a236887